### PR TITLE
update runtime to 21.08

### DIFF
--- a/add-appdata.patch
+++ b/add-appdata.patch
@@ -1,24 +1,24 @@
-From a6d7441be2b0a6475c12008c9e54582d0bd2631f Mon Sep 17 00:00:00 2001
+From ca64dfe2a7b713f882bea2517e128e52c548fd8b Mon Sep 17 00:00:00 2001
 From: Tobias Mueller <muelli@cryptobitch.de>
-Date: Sat, 13 Nov 2021 15:41:40 +0100
-Subject: [PATCH] appdata: add 3.40.0
+Date: Sun, 16 Jan 2022 21:14:40 +0100
+Subject: [PATCH] appdata: added 3.42.0
 
 ---
  no.mifi.losslesscut.appdata.xml | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/no.mifi.losslesscut.appdata.xml b/no.mifi.losslesscut.appdata.xml
-index 06f20bc..4e50694 100644
+index 4e50694..b0c60a7 100644
 --- a/no.mifi.losslesscut.appdata.xml
 +++ b/no.mifi.losslesscut.appdata.xml
 @@ -18,6 +18,7 @@
    <url type="bugtracker">https://github.com/mifi/lossless-cut/issues</url>
    <url type="donation">https://paypal.me/mifino/usd</url>
    <releases>
-+    <release version="3.40.0" date="2021-11-13" />
++    <release version="3.42.0" date="2022-01-16" />
+     <release version="3.40.0" date="2021-11-13" />
      <release version="3.37.0" date="2021-07-25" />
      <release version="3.31.1" date="2021-01-25" />
-     <release version="3.30.0" date="2020-12-15" />
 -- 
 2.25.1
 

--- a/generated-sources.0.json
+++ b/generated-sources.0.json
@@ -55,366 +55,359 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a",
-        "sha512": "bc6e92bc1ea860486f822b193454664425242f3d7573bae9fad6cd4f29c6a9cea64b577901377fb06c95e96d0a6599d744a313cd90d18104f73aef6386901f52",
-        "dest-filename": "@babel-code-frame-7.10.4.tgz",
+        "url": "https://registry.yarnpkg.com/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.2.tgz#cd6d3814eda8aee38ee2e3fa6457be43af4f8361",
+        "sha512": "25d11acf1eea895a93073cc1979ae8951c25e5c9a18a18df21ca6a4732198ed4fa6f5f258959839ff5655a9a96e02fea3f686b14530b455d7095ec7c65504f4e",
+        "dest-filename": "@apideck-better-ajv-errors-0.3.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f",
-        "sha512": "66dd72a1d071d5473289e3cc4a45a753884faa1c2aee11a2da714bd4b780dc4525faad8b431d7a3084a0274fb3edd9e682f3fd42d2257ae11318e88e1f545c23",
-        "dest-filename": "@babel-code-frame-7.12.11.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789",
+        "sha512": "8805ea527f0821e05335def6c6c16581a5c790c04cb7acb81c9a75b4868ae3ae4258b4ff7c6d5aa81ef292bf798071e69417466c579659fc81e0d249d2799e22",
+        "dest-filename": "@babel-code-frame-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658",
-        "sha512": "1d5d429b443766ba4247dded9163988ae60880bc595d91551b65602be3015a352a653ba776ea5b7f1d9a5daad7bb0e4aa3968c723b4981b4ace2f506052e6fea",
-        "dest-filename": "@babel-code-frame-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.8.tgz#31560f9f29fdf1868de8cb55049538a1b9732a60",
+        "sha512": "9bb3a45f421d28b28fa41949b45e7ad5825a979cbf8f22397cd7d66cfc61d83fe76f3cc6238a91cab0fcc4eda3076e2eee5fb92366b8dec7021b622b7e30b9d1",
+        "dest-filename": "@babel-compat-data-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.12.tgz#a8a5ccac19c200f9dd49624cac6e19d7be1236a1",
-        "sha512": "dde249f38d6e2b1795f1d70dff6c86114cbe45f810b293c48106adf39ba6b04d6ba2dbaab90d806c8b9be12ea3edce746b677ee26c9cfb34a59d77881eb3a785",
-        "dest-filename": "@babel-compat-data-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/core/-/core-7.16.7.tgz#db990f931f6d40cb9b87a0dc7d2adc749f1dcbcf",
+        "sha512": "69e2daa9ca938513596266ccaadba5b1eb4e419ff981b47f756aee50225ca5ab38428cb2f9079a81f0ec3dd32bab0b0f44337126f065462671c57ed31ceeeab4",
+        "dest-filename": "@babel-core-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8",
-        "sha512": "d2a5dc658299a77ffa3768ca615c59bf468d0acc534950a22bbd834e24d8640bbbb2383bdd6d3f6b29d68cc6e219df3b1102f85b203cade889561f7601595af6",
-        "dest-filename": "@babel-core-7.12.3.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.16.5.tgz#48d3485091d6e36915358e4c0d0b2ebe6da90462",
+        "sha512": "994a986b8ea5816a87290df743a2cd086a7fc0f4777aa3984d48b11c5b1fad242a4711f4f963b371aef98848c5af9443187d5d0f3eb6d8b68784b3b33ae41150",
+        "dest-filename": "@babel-eslint-parser-7.16.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/core/-/core-7.13.14.tgz#8e46ebbaca460a63497c797e574038ab04ae6d06",
-        "sha512": "c19b28fefc85e248b4974ce79603388a7c5b76b52f09bf9c573f20af10eafba0bd93aa9baa8209b5e40e2a271a2a30a2a54dc8495f9779d0aaa4bd9124955e84",
-        "dest-filename": "@babel-core-7.13.14.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.8.tgz#359d44d966b8cd059d543250ce79596f792f2ebe",
+        "sha512": "d688d9c04f7e94e5f371675698ee936d4cc37ea2c3dfd0a612137cfb6717f57903a39c96d4ea607de8df962cac4760162e931a99388e880a7f9adae86b29a1a7",
+        "dest-filename": "@babel-generator-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39",
-        "sha512": "98738e998d00c65fc90939314d4e8b7f9b163a0feff2751af9792de333137ed5f4c2a99be9287b27c82f71e841c3bab4021ae1011f850da70a8c26765fc2be4b",
-        "dest-filename": "@babel-generator-7.13.9.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862",
+        "sha512": "b3ab76c3f20f4154c0113d478ada28c11197a285fc98282db8fe75f79c03fd024f57ac188e9ba308617b26e30e0d55f664024e7f5193e834fd307119bcb3854b",
+        "dest-filename": "@babel-helper-annotate-as-pure-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz#0f58e86dfc4bb3b1fcd7db806570e177d439b6ab",
-        "sha512": "ed85df5f9c10e5a60cfc13a56d271c1c36ee5d714fc5ea1499f5adcfc95edb24e44d973e071b2212710d1688b64a5980f1ec03906d8b808308573ce7da1f247f",
-        "dest-filename": "@babel-helper-annotate-as-pure-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz#38d138561ea207f0f69eb1626a418e4f7e6a580b",
+        "sha512": "0ba15d6d16b1623c15bbf81e296e19790d10df501fb6045c7529d9e7f8ec1fa0730896edbd7be1a5f91b9138584aebad640ee7097a4f47a003f73775769acc90",
+        "dest-filename": "@babel-helper-builder-binary-assignment-operator-visitor-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.12.13.tgz#6bc20361c88b0a74d05137a65cac8d3cbf6f61fc",
-        "sha512": "0993aff6d1a98610d19558d5900826f0d864966f51cd2996a57da6cbeb7b51afca4fad7aa44cd7b100a38a7cef911bc7589f62b4ee1fdbde9e7eba17db75c230",
-        "dest-filename": "@babel-helper-builder-binary-assignment-operator-visitor-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz#06e66c5f299601e6c7da350049315e83209d551b",
+        "sha512": "986a23070216730183eab7ea8115d59556263c0bfb78ea487a6506ddd1a70dd098e0f69eef444e8a3dd799fac7e856b58756a20f29698256d9ca4b5fcf2a3f84",
+        "dest-filename": "@babel-helper-compilation-targets-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz#2b2972a0926474853f41e4adbc69338f520600e5",
-        "sha512": "ab591c7473597a10700fd8d83e1dd6c9772c144462dfd5f8239f48dcd69d7225ad343c99eb1f866e83b19dc14ad245e5288bfa0499b969c9dc7a15d652359031",
-        "dest-filename": "@babel-helper-compilation-targets-7.13.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.7.tgz#9c5b34b53a01f2097daf10678d65135c1b9f84ba",
+        "sha512": "908168cc0bd57cad390cce0455060a2beced796bd8f39045746051401cad472637cbee8f5f40e40ce9ff099de512e73309fac2c44cf0b7462d3fff3b60f4d64b",
+        "dest-filename": "@babel-helper-create-class-features-plugin-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz#30d30a005bca2c953f5653fc25091a492177f4f6",
-        "sha512": "6b2b3423b5d8abdc5b8c24af4fe12fcac2e07dcded3a4c0250b1e3ae7b1c193dc0f6a0f8b24df05e7277a1fd0c016b161a37629c5bda8c7536b2662ea9728caf",
-        "dest-filename": "@babel-helper-create-class-features-plugin-7.13.11.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.7.tgz#0cb82b9bac358eb73bfbd73985a776bfa6b14d48",
+        "sha512": "7e4e40eb299fa7e3b9fa9db20a45c0bb92b28fabf4c61d1105e35c024614303bef000a31bd22979fe25bdfbb7fc961624150c52b510ba544c3f3f68b8423eefa",
+        "dest-filename": "@babel-helper-create-regexp-features-plugin-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz#a2ac87e9e319269ac655b8d4415e94d38d663cb7",
-        "sha512": "a76546981bbda1e7cb6769d0a609c49c6d199513ef2fc8001af3d4310c1475a13c938f6b38cb99a4ec1d428cb9a897fa2bc8cbddb70032155494702322024752",
-        "dest-filename": "@babel-helper-create-regexp-features-plugin-7.12.17.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz#c5b10cf4b324ff840140bb07e05b8564af2ae971",
+        "sha512": "ee17d3f255258e5fed33787e8b34d7fe93b75b77ebcf6a24e8f93e833cacf2226a0df66b672da95e3453640bc6d9899f1ee9f55f8abcfd46512dab4c7ea7394e",
+        "dest-filename": "@babel-helper-define-polyfill-provider-0.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz#3c2f91b7971b9fc11fe779c945c014065dea340e",
-        "sha512": "9d7bb3092c2527f58aafcab1cd6f35ea0c324fa559822246d7bcd1e347e8bbbd327c072a8e83724cb97f0d0f85131c391f1e4a36ab2198df0b765febd8dedc4e",
-        "dest-filename": "@babel-helper-define-polyfill-provider-0.1.5.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7",
+        "sha512": "48b2dbd00027e8f9147807ca24208e97d7b5479de94251807dce32e17b8c4597ea78c60b13474cd4b321a9b180946418d257f0e7fa21a185807bd575ca26d16a",
+        "dest-filename": "@babel-helper-environment-visitor-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.13.0.tgz#17b5c59ff473d9f956f40ef570cf3a76ca12657f",
-        "sha512": "a92d2978b4c33fc90e8ac1b56e529b6a8060fe8f4e49ad6aa2e98c8d32b9a4cf8a0d3b69c69b22b9b9c218fdf8bcaf015c671bd8cf5e8a0c20be826bcabcf058",
-        "dest-filename": "@babel-helper-explode-assignable-expression-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz#12a6d8522fdd834f194e868af6354e8650242b7a",
+        "sha512": "2b251e9e158c0bc56bc739063f4262ce3a38fd9c7ed67359860a1cb3e80bcf267207c48789d868abd28affc02da386a7870b22bdf9012dfb64cbb82fcdb64cb5",
+        "dest-filename": "@babel-helper-explode-assignable-expression-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a",
-        "sha512": "4d9be63e7d143aa9af8b91b8befc34a994e9569b46901d462fad51ea52afad2748c469b93e4cbb4377e92a222440202d442054c01d0f693865c7dbde6c20d2c0",
-        "dest-filename": "@babel-helper-function-name-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f",
+        "sha512": "41f0df127214cb20524771edaed1840ae67a0c0c82918169ec61e5ef9bc5b539e7ea98ca78ad13d4307994b905bc179af0c75a894001c77a2c6e02f2227a1e8c",
+        "dest-filename": "@babel-helper-function-name-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583",
-        "sha512": "0e3115cd0373e4b2029333744447690f9a6b1a889dbdb75893505581150e20d69624fdade9abc1dbb5f582e5cad645cdad7d1631fb2b9b503f641b6162e20c42",
-        "dest-filename": "@babel-helper-get-function-arity-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419",
+        "sha512": "7e573e44b48e057ccdcd585c2eeeae8de1d4ac3ead00d00e539a23ad1c7f6acfad6f37fcfacb540a3efe21f451a006c466a8ff6a15c432c8e13a181e66cae74f",
+        "dest-filename": "@babel-helper-get-function-arity-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz#5d5882e855b5c5eda91e0cadc26c6e7a2c8593d8",
-        "sha512": "d24073bd788829fb02034cba70510825fe0e7737e946e364e3e61378766918673aeba4804c5293cfab119dcc059d093bfee809e1d4ab0a3ea226ebd6e10c2bda",
-        "dest-filename": "@babel-helper-hoist-variables-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246",
+        "sha512": "9b4e1dff43a9df81f9bfba5b670ea948a3fbc1e03a96c32f7e220031e22f918fd1e3142d05230512282ef504d9daa07ff65db6becc6d33c6be43c0b30f6e797e",
+        "dest-filename": "@babel-helper-hoist-variables-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz#dfe368f26d426a07299d8d6513821768216e6d72",
-        "sha512": "e3caa5d422cbe7d68a6d4f7863cf1781bd95172edaf79ca41916c925a695bfe2d7e54f301692df8865c9246528cec980d68121fe8e41a7ad15a2aec00b203f4b",
-        "dest-filename": "@babel-helper-member-expression-to-functions-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz#42b9ca4b2b200123c3b7e726b0ae5153924905b0",
+        "sha512": "56d27feb9b58894ffa01b3130f0ca85c63ca1e04ec7d16ab8af9be61b079b80cca532b8f8e065280015e1bcec50a281ceca347bb63de821d57213de55e3bf3dd",
+        "dest-filename": "@babel-helper-member-expression-to-functions-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977",
-        "sha512": "e1c56f476ff507af7722e3af488db4c6aa9affe6e5ee5a80311e7d4788aedfd47d68e5fcfc9a18635b0568dbd43323011a71ddc2f26052bccd2e8519c57ca9c4",
-        "dest-filename": "@babel-helper-module-imports-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437",
+        "sha512": "2d5b52e93aa324715cfa761e213468e952d7bdeef4c66abbc0f8564ea0c9bac2448069a4000096c0c89336bbdfa10a3a844845c00222c4d92f0748cf5c32fc5a",
+        "dest-filename": "@babel-helper-module-imports-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz#e600652ba48ccb1641775413cb32cfa4e8b495ef",
-        "sha512": "42e53f389d2200e4886adc956667ea07495b9153f49034622a3df8c72f9036c9d5662fcf03a0684a8ade7aa9f1c5af441c50082f447d5ce68047f1bd5a5232e6",
-        "dest-filename": "@babel-helper-module-transforms-7.13.14.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz#7665faeb721a01ca5327ddc6bba15a5cb34b6a41",
+        "sha512": "81aaad2c3c4910509e41b629f5a2c079f8e190a76329c761e8307b8e7888194dcfcf9d960263f6ebcccad1580fcfd85436431261e1fdefa2b6fd8eb23da7699e",
+        "dest-filename": "@babel-helper-module-transforms-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea",
-        "sha512": "05d590868549929ea756307b9e4156727e37764a6b61abaab64fbe3f2d9e69ffc6443166e41c51a842190a21e5654180566b7029cb152f5742ebc5a6cde16688",
-        "dest-filename": "@babel-helper-optimise-call-expression-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz#a34e3560605abbd31a18546bd2aad3e6d9a174f2",
+        "sha512": "12d801860eeb77f25c9e96455e9072d337b56117dd9bb067057e2e28c05dde2c5add1180134d3625907ae85272347ee0d05dfc534e695e60393fc70187bcfed7",
+        "dest-filename": "@babel-helper-optimise-call-expression-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af",
-        "sha512": "64f69f20f4b0cd4940a164fc0cab355b657217680e5ad84677934614cb0170c32897e6612be11063f7ba57dea9a1ae8f03f061f82f699563748573b5b81f007d",
-        "dest-filename": "@babel-helper-plugin-utils-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5",
+        "sha512": "420dcd93b671a6032bb28c7a1eb798d5934a741abb2bbdad0d296203a7429797f4d3b8d1e277bc883e54cee3670891f6c417f60441151abfbf38be86769ed1c4",
+        "dest-filename": "@babel-helper-plugin-utils-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz#376a760d9f7b4b2077a9dd05aa9c3927cadb2209",
-        "sha512": "a5442914113d26f0bd96b41ba57d1399e348cb9b3b1a76639dada58617070bb0f3801b3a7d69fbdb663971fc20aedaea73b34027032f39ad262a1aba5da1388e",
-        "dest-filename": "@babel-helper-remap-async-to-generator-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz#29ffaade68a367e2ed09c90901986918d25e57e3",
+        "sha512": "7e6d201fb1656fc1f9d4ba891f2dc7277c27135faab5847603df4ad3a6a1c2b6b02dd385b021168d93ab62b89c5c91e83d2b9d34ac6b30150f1083f188822f07",
+        "dest-filename": "@babel-helper-remap-async-to-generator-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz#6442f4c1ad912502481a564a7386de0c77ff3804",
-        "sha512": "1b3d5e897fb8c833bc993fa1781f7868b54d08bfab6ee4f6c72e187f236abbc17e388eaf32f24af3dd6a1814ea2fd51cf30c44bd15bdd8877a1bbb037a7ddf17",
-        "dest-filename": "@babel-helper-replace-supers-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz#e9f5f5f32ac90429c1a4bdec0f231ef0c2838ab1",
+        "sha512": "cbdbec5a295335a567561eb18897c0073b0da600cf29ebfd1e7020cfa19bd69e945307fd35ea5d96c57b5571827ed24cfa3a83e5fec9204b9b7292e3663e5d07",
+        "dest-filename": "@babel-helper-replace-supers-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz#dd6c538afb61819d205a012c31792a39c7a5eaf6",
-        "sha512": "ec51236ebc7948bf5c5af5e2a036e79584e9a5c646b8263aa30dff0f9bcc8206f663082ee1d32ba53257d09750008711454125388c45df2128a1af6051bf596c",
-        "dest-filename": "@babel-helper-simple-access-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz#d656654b9ea08dbb9659b69d61063ccd343ff0f7",
+        "sha512": "648cc7572a1e2ccbd730dfefa24fdae0b591cbc1b6bf6d3998d3f45ceb9ff5744bc97e7fbbd0a756e954b438144da99ade54fe6dffd4aae72e663aa21ae4d2d6",
+        "dest-filename": "@babel-helper-simple-access-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf",
-        "sha512": "31fe4052e846d7f3820a1389fc77000e6bdc1cce36589a1c92899b9fc013246dce9f2892c412bf326e71efc0505af9ad5d928781b8dd18bda48a7fc738b95918",
-        "dest-filename": "@babel-helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz#0ee3388070147c3ae051e487eca3ebb0e2e8bb09",
+        "sha512": "fa2975813cb4a07c14b01419c89bee91b078bcf31d71806b1476b451ce008b32f16eae813980b9d51bf8b56a1c5fd04b0432d9e2473aa9416943a1d180bfb7cf",
+        "dest-filename": "@babel-helper-skip-transparent-expression-wrappers-7.16.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05",
-        "sha512": "b4224396d17cde1b54b57c7934b71a0ea466927bfae76656087ca84c44dfd425d825d3c2ee7a2166886352089e5e1bf485325d45fd858c3b9e15e85d36e729ce",
-        "dest-filename": "@babel-helper-split-export-declaration-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b",
+        "sha512": "c5b5a8cbf3c5a314966b3213a13f5289ffa325396b31c9dd22c68e2af4c0eaeed0128ee2964459a637b0d7cfd6ddcee79bc7d77540d7874d955d36d9d2918337",
+        "dest-filename": "@babel-helper-split-export-declaration-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed",
-        "sha512": "9e9fe51b7b80445c9b9281e89095267f541f12f45508f6e641e510a4aa30e5c437c56ad5f62deb507a1d28324f41f4d55fad6a2a2f9475893c92293ce27ed73b",
-        "dest-filename": "@babel-helper-validator-identifier-7.12.11.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad",
+        "sha512": "86c12715e99e896e03d3c039814019c4b0535e9677f4ff9af83183b07c35cb1ab243f8f31449f17f9b93106a7eddbcc06cd3b1535a5a4e0612e04094fc881f0f",
+        "dest-filename": "@babel-helper-validator-identifier-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831",
-        "sha512": "4e8a6430398bceaf27802870465ca347aada283ea031269ee097580c1f1b0722ab790806d11053b8a7bd2d1c56df016d5278f138f44a043c041fa320e4a7837f",
-        "dest-filename": "@babel-helper-validator-option-7.12.17.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23",
+        "sha512": "4d1b5e9ceb91515a3da084063c2e46f4380ae3be3771dc6fb4ec34c1e40da595da4b5e920818b930d8d917cbdb6b71135118d9a536d59fb56f71fd9e030168cd",
+        "dest-filename": "@babel-helper-validator-option-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.13.0.tgz#bdb5c66fda8526ec235ab894ad53a1235c79fcc4",
-        "sha512": "d545fd17b2b7052e367c8eaa7760380632b38068d3a2c732653769d438e49c72c222fa609deebdd7c8a8f9a2f92d715c111ffc4168b0a6863dd36a5512a8135c",
-        "dest-filename": "@babel-helper-wrap-function-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.16.8.tgz#58afda087c4cd235de92f7ceedebca2c41274200",
+        "sha512": "f11a724552005b545c0c319303e1a93c0c15db6c1709f28ea0cf5b7ade932e4188153911412907d67310e587ade0ca685ded59c073d5b4d6ac736c34b9932a9f",
+        "dest-filename": "@babel-helper-wrap-function-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.10.tgz#fd8e2ba7488533cdeac45cc158e9ebca5e3c7df8",
-        "sha512": "e153bcf37f8c58f0d45511773e188b054147a17fdbb0b4c616914afc7aafbdf059cf60f9eeef57ccf54d1550537343d6fc2591f415d338ab7c345e0322750771",
-        "dest-filename": "@babel-helpers-7.13.10.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.16.7.tgz#7e3504d708d50344112767c3542fc5e357fffefc",
+        "sha512": "f590e8aad7d8ec0b843adddcc5c85f8a2e82ec60f2c8c05f7e4b51e41da3bd6bfcbb6f9e7f0be99d5297316ccd7a1ab2ebcb4a8007d2c1f770fe55a9b614b66f",
+        "dest-filename": "@babel-helpers-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1",
-        "sha512": "e5a3e97b95d03f37e542b1702f5fd0a1e1e43f632c0382429ed7171d1844b1db1f3d592f3e2db0ed08b1e2257bb794bfa02f4ea1d1ab82077c69ca3583749916",
-        "dest-filename": "@babel-highlight-7.13.10.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.7.tgz#81a01d7d675046f0d96f82450d9d9578bdfd6b0b",
+        "sha512": "68aa4f31f2ef18edd0f7b574aa1c3f5764963569707c9927bb002e9d4ef064b49facce314c1be0ec4e68a54562d6425304a8a1137f023e0e27062a97f373d663",
+        "dest-filename": "@babel-highlight-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.13.tgz#42f03862f4aed50461e543270916b47dd501f0df",
-        "sha512": "3a1b3232bab281f939bfc1e65b03b39588c9aed2da161177e0cadf1bf67bdc3818088ea88cd513529d9361bb678e8f0f7a0789a75d9e6a6b0d7adb424232a357",
-        "dest-filename": "@babel-parser-7.13.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.8.tgz#61c243a3875f7d0b0962b0543a33ece6ff2f1f17",
+        "sha512": "8bb8c351fad505673eece29c07311ee67edf6efde2d9f5adc4acf30af3a39f34b131f58c8a0021b5f27bab364d18534cb0209debbfaecf9e777582965cfbc22b",
+        "dest-filename": "@babel-parser-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz#a3484d84d0b549f3fc916b99ee4783f26fabad2a",
-        "sha512": "774bb7cd629ca197f7efd7ce78976bd5ae563c39f2e1a38567a8657ca8af80ad0b63b67135fa1a1cbd9f5b0746b47c95beb6b7f050be1d56243be6f27d203c01",
-        "dest-filename": "@babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz#4eda6d6c2a0aa79c70fa7b6da67763dfe2141050",
+        "sha512": "6a7bff0ce6e5ef06a21849c2db83bdcea2f4a52b88f619638a1aa20ee1470bc77bfdb8ebff844b18f5ae73cad839f7ff40fcdb10f4a4cc6f30186f5a0ee84746",
+        "dest-filename": "@babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz#87aacb574b3bc4b5603f6fe41458d72a5a2ec4b1",
-        "sha512": "acf067863f968284a682afb881052d5f1fef39c53e518b63cb5000fda783eb51f08f8d747f0632a9f51c44fde547cb9c82589524bfc6eec5dc35479c0bbe485c",
-        "dest-filename": "@babel-plugin-proposal-async-generator-functions-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz#cc001234dfc139ac45f6bcf801866198c8c72ff9",
+        "sha512": "762f2f50745d7fee1a27b96d5e16836cfa2ccdd921e7d010b49339b282ecb87a5025d15064e038b868f4576bbf099f1b27fbbc50b0cbe72aba14efdb0979ca1f",
+        "dest-filename": "@babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz#a082ff541f2a29a4821065b8add9346c0c16e5de",
-        "sha512": "70aa7776542c16c12ce4258a9cdec19d21ce77410e5bc10aa448e4a33d693b61392b3203355f51a2cd5bd029e66d580019726e6ce61504e1824f53a6270388ef",
-        "dest-filename": "@babel-plugin-proposal-class-properties-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.8.tgz#3bdd1ebbe620804ea9416706cd67d60787504bc8",
+        "sha512": "ef560722f32e8aea9625091e6d626d7614137dde10e2617beaad885f7eee64f906f7ea25071b17fab1f5be4845b68e1478967d74f636b3e983be10e6d6ed8119",
+        "dest-filename": "@babel-plugin-proposal-async-generator-functions-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz#146376000b94efd001e57a40a88a525afaab9f37",
-        "sha512": "2a74c38c5342d60fb8e646b49b264dbd20452e13422cdf8678660b0c403c3aaecc67ac8c81f2e821187ce86453d058ed261670f09c94b243fdbaf8f9a4733d66",
-        "dest-filename": "@babel-plugin-proposal-class-properties-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz#925cad7b3b1a2fcea7e59ecc8eb5954f961f91b0",
+        "sha512": "2286d4d1799edf57b08d839285222a77f64633faff72e3b3db3d0c0db36b845e455be655822d1fda5c9ea23f4a14f0ce02ab18c662d666d7b558ec25bd8f5ac3",
+        "dest-filename": "@babel-plugin-proposal-class-properties-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.12.1.tgz#59271439fed4145456c41067450543aee332d15f",
-        "sha512": "927348baeb3272181837c7c624738d2f445b1712c66b085738934b064ef94e7893b1965e03ec1d903bafeb0a78946c334042a3662ebf598b676f7b9d34f99099",
-        "dest-filename": "@babel-plugin-proposal-decorators-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.7.tgz#712357570b612106ef5426d13dc433ce0f200c2a",
+        "sha512": "760a8926b719a06ff80a4328a7384f2631b1b087bd03c4659102e72ff561871f0003d66e691c064a5b1c4a1e3685acdced64abc9afc82bb9937a81740cff6d13",
+        "dest-filename": "@babel-plugin-proposal-class-static-block-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz#876a1f6966e1dec332e8c9451afda3bebcdf2e1d",
-        "sha512": "38d58a8f41fafb02110a4662f7349b66d13fafbdee3a13151e1db9eb2b345337ccec8ddde27faca593568ce9c9bf6833a29ba63f65b18b5f3abc8f0dd18d89c9",
-        "dest-filename": "@babel-plugin-proposal-dynamic-import-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.16.7.tgz#922907d2e3e327f5b07d2246bcfc0bd438f360d2",
+        "sha512": "0e81299ee5cad785d5f5bb48d64f2dccd182bad31c9698f8cabbbc6972a81e55666ced6cfb603e836fa1e0985c8ebc64149ab36f29a72c6ea3fe788e7f78855d",
+        "dest-filename": "@babel-plugin-proposal-decorators-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.13.tgz#393be47a4acd03fa2af6e3cde9b06e33de1b446d",
-        "sha512": "20d020b45a383a72cddd8fe3d15c00830dc70d7703b57f82fdeaccbd6cee57dbfbd6beeeadbea2c8c5eeede33d2202ebd4494b94e91a1e327449b0a674e43723",
-        "dest-filename": "@babel-plugin-proposal-export-namespace-from-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz#c19c897eaa46b27634a00fee9fb7d829158704b2",
+        "sha512": "23c496f47a37ffc0d149d983747de039177252e6279359b870cc5401dbb9a32e27dce7cdf1f943107f9deb4886edd51f8b42a46304afa1a947cf3751ce95874e",
+        "dest-filename": "@babel-plugin-proposal-dynamic-import-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz#bf1fb362547075afda3634ed31571c5901afef7b",
-        "sha512": "c38cce3ca5053d7d6682f4e62ff7dc12acb7e21ad0d4245c1b176984173ab270e79ea278ec4643232a29e88c17cc00bc1bdd7a86c22e5c1d99301084c42e64ed",
-        "dest-filename": "@babel-plugin-proposal-json-strings-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz#09de09df18445a5786a305681423ae63507a6163",
+        "sha512": "67176da835cb44604beb8a1c65cb3ba2fb7bd4bde3842d51192c91f7deacbeb0a2dcf62a1cd91bdd2c0f242b3c448cc3f3ab3e58fa6dd92ef7f841c218ef8d50",
+        "dest-filename": "@babel-plugin-proposal-export-namespace-from-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz#93fa78d63857c40ce3c8c3315220fd00bfbb4e1a",
-        "sha512": "6ae97ace7601e0de071b07889aa2a7e7d4aef514bc95b508ab1b574ce7001ad3480dcce8105bfe975121997f2b501a771b58cc8ca266f26d235d5a7add9a52e0",
-        "dest-filename": "@babel-plugin-proposal-logical-assignment-operators-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz#9732cb1d17d9a2626a08c5be25186c195b6fa6e8",
+        "sha512": "94d677104820b0663bf096af81b1ec2bdbb93f7a50696ee4e1ac658052d890c77b501b2235a8422134a12e3350b1c84fca3b4ee9d003acbdb8ef9ec876106bb1",
+        "dest-filename": "@babel-plugin-proposal-json-strings-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz#3ed4fff31c015e7f3f1467f190dbe545cd7b046c",
-        "sha512": "9d963411289a403235cbdebe8e4e95c4c39a2f82cfa3f4031c1a8bf92177fef97a747913c0794e23c2f8670b9104781a911070e73b15ca57a5ed03db6c6b9882",
-        "dest-filename": "@babel-plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz#be23c0ba74deec1922e639832904be0bea73cdea",
+        "sha512": "2b75f3c99246402af4d3e12d62dac38e6c17ee8ecf2cae94f5b8b59c2c24422a1115552fe9d268c5b423b5656d3fe6c23f2f366ce341286f0d3f2438fa2eb28e",
+        "dest-filename": "@babel-plugin-proposal-logical-assignment-operators-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz#3730a31dafd3c10d8ccd10648ed80a2ac5472ef3",
-        "sha512": "89e3e50cf067fff521c44c724bd2b279853b44cf5649c006f83dc7867a343cb25e6c01290d932871b0deeb87aaca784d027c33fef6682ffabf401d93d4e1f7f4",
-        "dest-filename": "@babel-plugin-proposal-nullish-coalescing-operator-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz#141fc20b6857e59459d430c850a0011e36561d99",
+        "sha512": "6943ab614dc456d8dfeb68d0ac28fade9619ee4eaf9ecda1fc342f1cf5869ac25163359767afc0b1f829891cba5e2b880c00e12733f643d33048c29ab8143e51",
+        "dest-filename": "@babel-plugin-proposal-nullish-coalescing-operator-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.1.tgz#0e2c6774c4ce48be412119b4d693ac777f7685a6",
-        "sha512": "311ece93e01fdce84d4c2c585632591d2d2df7bc9d9c966dfc36d1e162123b7f620e78620fc5c7ad8d76c6e489f741451068e2af4173cb29fb83fcd8ea1c5bc4",
-        "dest-filename": "@babel-plugin-proposal-numeric-separator-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz#d6b69f4af63fb38b6ca2558442a7fb191236eba9",
+        "sha512": "bd080f3249ce2208ae56a6e8913a325db918fce9a68c0cebff49614886c6fca9a7cd73c6c16fc076174aa62f8ee17fd59168968e790a3818aa26b4da0bdf152b",
+        "dest-filename": "@babel-plugin-proposal-numeric-separator-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.13.tgz#bd9da3188e787b5120b4f9d465a8261ce67ed1db",
-        "sha512": "3b58c589af51f0150297764607b7a2b5a00fbbad935c94479fbae1fa88cd111085caa47024c4e6873fad27e9340b023a08b8d7fde7b8a96ef8152aa5abd237e7",
-        "dest-filename": "@babel-plugin-proposal-numeric-separator-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.7.tgz#94593ef1ddf37021a25bdcb5754c4a8d534b01d8",
+        "sha512": "dced18e3e770f781c0f3aa9283d2077f23e4b6047bab782935501e88a41dfbc8c1285694e4d412d586ad828e3063e50536e2e3bf17129b372c1eaae1813c8150",
+        "dest-filename": "@babel-plugin-proposal-object-rest-spread-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz#5d210a4d727d6ce3b18f9de82cc99a3964eed60a",
-        "sha512": "0e107612e075221ed2dff2115f9005560675ea4dc4cdf45babdec2c40548d4a498716fa57b157c5596fb1bb2fccee3d549d40c467d24881a5ffd8ceef59287d2",
-        "dest-filename": "@babel-plugin-proposal-object-rest-spread-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz#c623a430674ffc4ab732fd0a0ae7722b67cb74cf",
+        "sha512": "78c387fcbe0ebd6499004d559076ebd6f7242c6d5651c1c62522eaa90c25d86694a86e908dd76face69350c3588afefb1f920a3cc67d53d3fb11a1f0bc04a17c",
+        "dest-filename": "@babel-plugin-proposal-optional-catch-binding-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz#3ad6bd5901506ea996fc31bdcf3ccfa2bed71107",
-        "sha512": "d304bfe03505d42b93986a3e3626877c771549e48b8f94b77ba462bcf4e0ff6937c0ebf78cedf9b59ebf656b1085032f76023b0b0a618d06bf71c6ab2f298754",
-        "dest-filename": "@babel-plugin-proposal-optional-catch-binding-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz#7cd629564724816c0e8a969535551f943c64c39a",
+        "sha512": "782df1cbe66b51c06d3fbc7eb2aeb643f1d877aef8a4f4dbffbed764c6f9c1b0cf19621d51b4abe0082bd39dbecda50f49bfa01919e3c577ca16fc7988c27e0c",
+        "dest-filename": "@babel-plugin-proposal-optional-chaining-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz#cce122203fc8a32794296fc377c6dedaf4363797",
-        "sha512": "736b91a58e96cda543cf29d563d962cb2912fa4554f964593cc3d8a647a55c7f0a06dd685e823cf643db64a286fe30d3e542bdd854d6d9f66465a26176205a6f",
-        "dest-filename": "@babel-plugin-proposal-optional-chaining-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.7.tgz#e418e3aa6f86edd6d327ce84eff188e479f571e0",
+        "sha512": "eedc15de9ce1ad1c52c07788bc513a7283e0be8f9ec4d0ce88650c837f68d8b88ba3563ee1a2a97e470b19c835507a27ce8ac2b7b48d5e7a0cc829e720e03c4b",
+        "dest-filename": "@babel-plugin-proposal-private-methods-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.12.tgz#ba9feb601d422e0adea6760c2bd6bbb7bfec4866",
-        "sha512": "7dc11d28e90807b4dfe08c6b80455e142e33789493afbf27a3dc13741b9965ba85eb8933965534c9ba36cebce6ee05107f11a1060ab8137f6846cf19c7f44c61",
-        "dest-filename": "@babel-plugin-proposal-optional-chaining-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz#b0b8cef543c2c3d57e59e2c611994861d46a3fce",
+        "sha512": "acc4248dc3856e6fae7deddb4d92f239fb0e50ec72bcb5d92424c046126bfbc50c4a8666a937b52b506090572b5b7eeb01c856839ef223af4e471896bd420db9",
+        "dest-filename": "@babel-plugin-proposal-private-property-in-object-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.13.0.tgz#04bd4c6d40f6e6bbfa2f57e2d8094bad900ef787",
-        "sha512": "317cb229077d8a7871d640d83e415154e057436d044bc3eda374fb519f76c63da66341150fca005737b262e55fcbf9b101d4d221ac8ebe0f9a5737075766e7e9",
-        "dest-filename": "@babel-plugin-proposal-private-methods-7.13.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.13.tgz#bebde51339be829c17aaaaced18641deb62b39ba",
-        "sha512": "5f226666274d7e87c492a155e550bf6cb69b1a63b94337a73cefd839f1ae11b814fb6b12c0c9a2a3760b6f85ad06072699dc191f2572bfca27efb2148d0e46be",
-        "dest-filename": "@babel-plugin-proposal-unicode-property-regex-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz#635d18eb10c6214210ffc5ff4932552de08188a2",
+        "sha512": "4112b4608ff8d152e13551888d13400109041f0b3472cc12745163a45cadf78dd8989214d5d6bdb96eb722ee8d155e82c53656e5e4c30abc1952cb415a0a7f46",
+        "dest-filename": "@babel-plugin-proposal-unicode-property-regex-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -440,9 +433,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.13.tgz#fac829bf3c7ef4a1bc916257b403e58c6bdaf648",
-        "sha512": "470e9a2171aea832ebebf2e8041604e7b9ca3b3429cff68390a94ca84c07f95a743176c6e87fd37d18da637e372cac7300a00c5c81ec43c2736992ae0d9f4cc0",
-        "dest-filename": "@babel-plugin-syntax-decorators-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz#195df89b146b4b78b3bf897fd7a257c84659d406",
+        "sha512": "6fe6323e6afa95dc8d9cceaca9878c584f9b809709a4eeb24b8403ef29b1807df81813cd0ccfd31c187c8ae9f2bca219ced8b02c7e02259d11c5393d7a68298f",
+        "dest-filename": "@babel-plugin-syntax-class-static-block-7.14.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.16.7.tgz#f66a0199f16de7c1ef5192160ccf5d069739e3d3",
+        "sha512": "bd0f8fc4bfacac0ee0e91c7a2357b5e66e7981fb649e5d97f060945b52539644da5d92c9392d1471a63478af63613ec861fe1ac27eaac328215472c3cf55b233",
+        "dest-filename": "@babel-plugin-syntax-decorators-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -461,9 +461,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.13.tgz#5df9962503c0a9c918381c929d51d4d6949e7e86",
-        "sha512": "27f458c679522d764b551ef04d1b28cf1293f2a6ecc7598d289cd71048d0d0a8f1d590027321e06da9cd58d085b5cdfa233b9685858fa6f2451687b1a0e58598",
-        "dest-filename": "@babel-plugin-syntax-flow-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.16.7.tgz#202b147e5892b8452bbb0bb269c7ed2539ab8832",
+        "sha512": "503a3760640ed231facadcd5c2048bbfd8bf0b331c5236ca7a72faedd4eb0193cfbfa18502d0e17ba8ea9ef9a82b30bfee1b4d4e8861a2cfa89cfb4332a27069",
+        "dest-filename": "@babel-plugin-syntax-flow-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -482,9 +482,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz#044fb81ebad6698fe62c478875575bcbb9b70f15",
-        "sha512": "7781ccdb74352bba2afd22cd986ea646df3997672c990d1c1d16b14578ca5b46057445ea959e64cc540a1f951cdeb0c910282efb209180f906d38326f7c47fd6",
-        "dest-filename": "@babel-plugin-syntax-jsx-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665",
+        "sha512": "12cc6693b62303c432b0a793dd58535ef17acbbedffdaf75488b38a566f81f6796190902285810686ea176811566d1acac071bd8ae415bae97b0e12b0f8594dd",
+        "dest-filename": "@babel-plugin-syntax-jsx-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -531,408 +531,366 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz#c5f0fa6e249f5b739727f923540cf7a806130178",
-        "sha512": "03cd45f690f0c92ef233ffcac1b0920eacb7523e0d308babb69971a615b1a18b4d3e8bfb709b0390014d372565219de3c06c9c56cbab67e2ed380f20677efa89",
-        "dest-filename": "@babel-plugin-syntax-top-level-await-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz#0dc6671ec0ea22b6e94a1114f857970cd39de1ad",
+        "sha512": "d30567a7d77127bd995090d5dbb65f6d28fa8872e8cad6199a1deb15cc4d9efb0917792d9332c364fcbf980d7b1c6b1a413dff0d0b16617d5fd50196902a1552",
+        "dest-filename": "@babel-plugin-syntax-private-property-in-object-7.14.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz#9dff111ca64154cef0f4dc52cf843d9f12ce4474",
-        "sha512": "7073f7bb52625221b62c50ca6d79f055a77cd46bdfc883a6083e8720421dea88eb6340eb7f2daad63c3b07037b744f38fa44e70632e45e82f7204cbfdc93eedb",
-        "dest-filename": "@babel-plugin-syntax-typescript-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz#c1cfdadc35a646240001f06138247b741c34d94c",
+        "sha512": "871fbeba92efe54d6b8187f07b5c41414851994e35344be952fae9f2392b48276f1929cce7fa9d44cb72949e8f1b938590168791b4c02939dddff63211244717",
+        "dest-filename": "@babel-plugin-syntax-top-level-await-7.14.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.13.0.tgz#10a59bebad52d637a027afa692e8d5ceff5e3dae",
-        "sha512": "f7a96025a8286de5666b35c5683adb9822d0c41cac2aeed4e83a3798bb31dbb81fe4393ce5ecf2b2bb360595295c3ef4dd4fd2bb5c53043c716abda86b88c01a",
-        "dest-filename": "@babel-plugin-transform-arrow-functions-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz#39c9b55ee153151990fb038651d58d3fd03f98f8",
+        "sha512": "6215082471c692a3e011c31890f08a4f219476818a5ada29232710ca3247f0e8ef460398b17b1a29e84b54f49c28958050b3f131ae0dd6f09eeaccd1105959ec",
+        "dest-filename": "@babel-plugin-syntax-typescript-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.13.0.tgz#8e112bf6771b82bf1e974e5e26806c5c99aa516f",
-        "sha512": "de3e84d34e03c742b77869a1c55271c3023cf424c9adc7bb960dd4aed16e0c0550ff6f9227f87f69214e784ebf9f4581d46b0e7dfb09a7a3273d0350f279b086",
-        "dest-filename": "@babel-plugin-transform-async-to-generator-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz#44125e653d94b98db76369de9c396dc14bef4154",
+        "sha512": "f5f7e414531bbf34efbfeedd4e9ffaeb1bd9016012b8f0f94e5f4b2b767dbe13a600da3a8fde2b8a4fb960c06de02c0754c58b5a932cae221cdb3b1add65b7c5",
+        "dest-filename": "@babel-plugin-transform-arrow-functions-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.13.tgz#a9bf1836f2a39b4eb6cf09967739de29ea4bf4c4",
-        "sha512": "ccdc85a9b737908fdf569ab07ea920e91bc1805a42e09d7c68a28c9afeca750ff51a04446a948903290b3153707d118edc1b478f7610665f24c425cf7153157a",
-        "dest-filename": "@babel-plugin-transform-block-scoped-functions-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.8.tgz#b83dff4b970cf41f1b819f8b49cc0cfbaa53a808",
+        "sha512": "32d9949932501c29f2255ad270dccd9687d027774b16ea1b627de6c0e4ca1e748232d6cdb2abc5ef51909897c58ddad74ac000ee2cac166616c386d7676d213a",
+        "dest-filename": "@babel-plugin-transform-async-to-generator-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz#f36e55076d06f41dfd78557ea039c1b581642e61",
-        "sha512": "3f1c1ed22a96257e1f38e33690465e52e0311cc59bf672bef68879775d5bb0ba01d31320fa6903a6dd1e62e0d907b113ad8f5b6dc5652941933865b2ec11ec31",
-        "dest-filename": "@babel-plugin-transform-block-scoping-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz#4d0d57d9632ef6062cdf354bb717102ee042a620",
+        "sha512": "254bb3973985e3467d717cb2b5c6d911929c920ad0cc285b409c3fe4fb841d87aacc2b2f79b0f1d0ad235a720855c9a60ce01572d0a09d8b34a4c72b623db326",
+        "dest-filename": "@babel-plugin-transform-block-scoped-functions-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.13.0.tgz#0265155075c42918bf4d3a4053134176ad9b533b",
-        "sha512": "f41b4708f500472547d685c6712243dd8a6ca912d1389c7964d3fab4de6f9e4d7b3744957fd582b5ff0dba1d42166801c8a28020cb2d8ad29dba80a6b1a0cae6",
-        "dest-filename": "@babel-plugin-transform-classes-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz#f50664ab99ddeaee5bc681b8f3a6ea9d72ab4f87",
+        "sha512": "39b65ebf69f1540600e1b872bac10b768f616f71fe039e9bc47dc564c6c42266458840d85475d0489d6140a1650e796df06f5b06b099e59a5445952b5781b9a9",
+        "dest-filename": "@babel-plugin-transform-block-scoping-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.13.0.tgz#845c6e8b9bb55376b1fa0b92ef0bdc8ea06644ed",
-        "sha512": "451a93613799919033f166e278b4ef294114c599544dd98be4a18cc998fb16731f2cd295e3eaf9e78f5a3911bf9a0a2346616540c24352ea7000c885d90ece52",
-        "dest-filename": "@babel-plugin-transform-computed-properties-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz#8f4b9562850cd973de3b498f1218796eb181ce00",
+        "sha512": "598ee8837f1214019845eeb806b8ca7fc3ab13aba5107b6be63118699330a31f4a79b82a3e2ebb66acfc2b9dc42a4d5f1442609bdeabdf6ae4299dea0369c259",
+        "dest-filename": "@babel-plugin-transform-classes-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz#c5dce270014d4e1ebb1d806116694c12b7028963",
-        "sha512": "cf29b97a6eed78fa0d4fdb3deb8734fca53724f3e7baaed5848c4f45e7c9e3fb3cd9c0feab59a029fb864433023cbd074f22b3e1d212b90942bac7e0089f3a1c",
-        "dest-filename": "@babel-plugin-transform-destructuring-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz#66dee12e46f61d2aae7a73710f591eb3df616470",
+        "sha512": "80def61bd6dc99e9d520b8fffecbf5ccb35a3f261c3b3521a36948241321fe26a427dca00a8fe1105f5ca466fad5208c103c5b6f2068550c6bb7e6d62aee4a1b",
+        "dest-filename": "@babel-plugin-transform-computed-properties-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.13.tgz#3f1601cc29905bfcb67f53910f197aeafebb25ad",
-        "sha512": "7e80eba3313ae5915d502d8e7e078e0ab10f4f1741df28eac695e1f021fe8a977d087778b3f8aaf3591c529c87f000863443dd16a6edcdf8336d3fd91a56c379",
-        "dest-filename": "@babel-plugin-transform-dotall-regex-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.7.tgz#ca9588ae2d63978a4c29d3f33282d8603f618e23",
+        "sha512": "56a0308531c19eee710550c2bebbea25bb4b51afbea996960b4160af69aaa24065ba5640446c88bd90e8a9b3e53da288990f5d280702cdbbfeba5fffbaabbbd0",
+        "dest-filename": "@babel-plugin-transform-destructuring-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.13.tgz#6f06b87a8b803fd928e54b81c258f0a0033904de",
-        "sha512": "35f0032628877612c15b7a6e949949236341d2de1c722e164d9f05b5d22e35cdbef29b255dd3ed4510045aa518fa6f6434e93679161b4c03a2a40c65ace730c1",
-        "dest-filename": "@babel-plugin-transform-duplicate-keys-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz#6b2d67686fab15fb6a7fd4bd895d5982cfc81241",
+        "sha512": "2f2b6d69aa364a3645e8f7f8be4d5d54abfc632a4ca689806f2816fa65397183f74b97164df0898c6f3157a08577318595f58af352232fdbe2893be96fa1bb81",
+        "dest-filename": "@babel-plugin-transform-dotall-regex-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.13.tgz#4d52390b9a273e651e4aba6aee49ef40e80cd0a1",
-        "sha512": "7db51e9643356a9bea7b3ff2631d7fa080959c6a3628ce6ceb79a11b296b9975312bf2005d221ff3b408c557d995d59fe10b0e69f63abd5ddb5fc68c1d2bcdac",
-        "dest-filename": "@babel-plugin-transform-exponentiation-operator-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz#2207e9ca8f82a0d36a5a67b6536e7ef8b08823c9",
+        "sha512": "d370efa5b45fbd6217c8ad3fe90891d4a31359e4fa39c43bb5b863ad7c854b4da48ee5ff9aee41be78794834961f1c9ac22b7683969684ac08f3a104ec65274f",
+        "dest-filename": "@babel-plugin-transform-duplicate-keys-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.12.1.tgz#8430decfa7eb2aea5414ed4a3fa6e1652b7d77c4",
-        "sha512": "f2102d926b106f7eb232612d936259f499d5c834a70ce76507ed27106cc80cbb8ae3247725c1237ee14f6247443d287c21dfab00c781127f97d22544ca1a3a1e",
-        "dest-filename": "@babel-plugin-transform-flow-strip-types-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz#efa9862ef97e9e9e5f653f6ddc7b665e8536fe9b",
+        "sha512": "f1460b4a5c8b8118b142f9581f72767a45c51c314b42eb5dcbb15f140326dc23d9eaaf701c2c27532897a5009ede05559d09477399ecba2115ce2b5e44d4d710",
+        "dest-filename": "@babel-plugin-transform-exponentiation-operator-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.13.0.tgz#c799f881a8091ac26b54867a845c3e97d2696062",
-        "sha512": "207293d349b0515604d33cdb90380d44fe92473bdf18262c3b1211cfc2ac89a68709c4fd0562243be1fd41126c78704b38605990751d1e2aa3eabd0f3ac772b6",
-        "dest-filename": "@babel-plugin-transform-for-of-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.16.7.tgz#291fb140c78dabbf87f2427e7c7c332b126964b8",
+        "sha512": "9b3982ab770db03a5966ef45003618c9f64920ead238d987728a765c428f74134c6b83c30b8784bdc3afcd968235c8cabbbdafd17425039cb5839f1a2d15dd62",
+        "dest-filename": "@babel-plugin-transform-flow-strip-types-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.13.tgz#bb024452f9aaed861d374c8e7a24252ce3a50051",
-        "sha512": "e8aee0672706d1c988c3017bb8c2bf66a7828a40865417723f627948a3425cee4438772a8becfb2707fc026c8335c060c444fc0eb12d0adfe63ca3f20335f2a9",
-        "dest-filename": "@babel-plugin-transform-function-name-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz#649d639d4617dff502a9a158c479b3b556728d8c",
+        "sha512": "fd0666f56f763eda70eec8c8f4dc7599b72c5b3df7fa5f24b8c2109c3c204011b9b377c07d0be446343b36a5e1b4d70a3a73e47480a6507c826965b4e870acaa",
+        "dest-filename": "@babel-plugin-transform-for-of-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.13.tgz#2ca45bafe4a820197cf315794a4d26560fe4bdb9",
-        "sha512": "156f963e3491ee1894c4c70aab23633f4e6d4369260427691296476350119bdead19008206f5ca9e98c82ed0e99549c9fde1d9d2500b2ccf9dda53054a9609ad",
-        "dest-filename": "@babel-plugin-transform-literals-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz#5ab34375c64d61d083d7d2f05c38d90b97ec65cf",
+        "sha512": "494fc2ebc615c13471a968f9920b1b28835a9066a0d0a4e0abd7f6899117752b6801b3b32c7101458cc89a603ac85a3c61984955f96f5e620750eec65879b1c4",
+        "dest-filename": "@babel-plugin-transform-function-name-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.13.tgz#5ffa66cd59b9e191314c9f1f803b938e8c081e40",
-        "sha512": "9312e43ac83cca2af861e10f1cbb8edad5cff51fe04e3a6e4ce8ec86a4a910b50ddd9020da37c39ca52fcf327139bba7dfcb30df09b852eebdb17ff303b891be",
-        "dest-filename": "@babel-plugin-transform-member-expression-literals-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz#254c9618c5ff749e87cb0c0cef1a0a050c0bdab1",
+        "sha512": "ead1fc453a53588d2cdac57abaaddefc2f703e8e0f4eaa99a6ce2e17493343dff13cb150b62a729ef993d60fdd39f109fb4110b0786443fcf244877c2766fccd",
+        "dest-filename": "@babel-plugin-transform-literals-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.13.0.tgz#19f511d60e3d8753cc5a6d4e775d3a5184866cc3",
-        "sha512": "10acbf136347858ffa570e5dd64deb828a1b7ed70d526a7d7c68dbf5767040bb5372db1104e4d13bb4471f17c8932d6880c37907137ba7db8c0374b33dfa2d31",
-        "dest-filename": "@babel-plugin-transform-modules-amd-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz#6e5dcf906ef8a098e630149d14c867dd28f92384",
+        "sha512": "981aee44c6e4b4a4306f1689a1fdf62d3f4a2f2d9fde01fedbb6b95d2b97a3a87b477bea96d9743e067cd02f1930ac3df017fc6eab7a044562decbce8763f333",
+        "dest-filename": "@babel-plugin-transform-member-expression-literals-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz#7b01ad7c2dcf2275b06fa1781e00d13d420b3e1b",
-        "sha512": "f5088ec783041a095f619e173a753bf4e1ebeaf21651a9088fd6f89a2a0df1e408a0487ea5fe69ff3101dfa2690c5580d769cd32245fedb7e846f97d467efd07",
-        "dest-filename": "@babel-plugin-transform-modules-commonjs-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz#b28d323016a7daaae8609781d1f8c9da42b13186",
+        "sha512": "29a684b6004bec5298c2327fb5e1fade802613794fdf837792c873f269b854c030ed4dcfc63570c149b110592c6e0b0d51a3b7c0877d4760154184841916b6fa",
+        "dest-filename": "@babel-plugin-transform-modules-amd-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz#6d066ee2bff3c7b3d60bf28dec169ad993831ae3",
-        "sha512": "870a9cb4f62384ce9c5af54894e21edbb8c22018070ac747db10895406109bb579c933288a56d5322f5feb02a0d2ba5000e9fa646e003b2bc2a8517f85487af8",
-        "dest-filename": "@babel-plugin-transform-modules-systemjs-7.13.8.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz#cdee19aae887b16b9d331009aa9a219af7c86afe",
+        "sha512": "a1f94a3efb0b4f6fae290a297ac26ddc0a626884b61d6fa1cc715cc1136dc831a2780782fdd207657f1bb894362765f5af118fcb87917148a39b7a9c48f8d870",
+        "dest-filename": "@babel-plugin-transform-modules-commonjs-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.13.0.tgz#8a3d96a97d199705b9fd021580082af81c06e70b",
-        "sha512": "0ff20bcc087abb2be45a328ac8513f5b41735b06acbfabcf4d2a8f723c45aa7e90a57deef038d15658aae05d816a63b659e7bfa26d3a572cbebcf90dadde30c7",
-        "dest-filename": "@babel-plugin-transform-modules-umd-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz#887cefaef88e684d29558c2b13ee0563e287c2d7",
+        "sha512": "0ee2b913793e4109a73aa051f5492eb01cb2e56656191c5fcd5e76f6cf673eb6b5184ee8966c5fa8ed851e86c439848f2233c14ebe29eba603723427b7c7019b",
+        "dest-filename": "@babel-plugin-transform-modules-systemjs-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.13.tgz#2213725a5f5bbbe364b50c3ba5998c9599c5c9d9",
-        "sha512": "5ec9bc3f686be61031c986e5adf0025e940a7506f1e26d9d7fdfd965243c30086c69dc34ebe8d6eecf73b12c3a85efa62595d1955332127564b49a38ce393558",
-        "dest-filename": "@babel-plugin-transform-named-capturing-groups-regex-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz#23dad479fa585283dbd22215bff12719171e7618",
+        "sha512": "10c87bba896c0bc3b8c61b9d17617ac1e75b4879b51c76740ba689ecaebbcdc0cd89d33355cc56746afe86d5bd9f6d64966f9b3a7f91c78081b009ed65ddeb11",
+        "dest-filename": "@babel-plugin-transform-modules-umd-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.13.tgz#e22d8c3af24b150dd528cbd6e685e799bf1c351c",
-        "sha512": "fca63685b2f1ac6e464d0f73cd949cdf15a23b2dfbf692044c485bb73c19730f6bbee69557816acbb0581983966676a85c84186db274ce25cb6bfb0a70609811",
-        "dest-filename": "@babel-plugin-transform-new-target-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.8.tgz#7f860e0e40d844a02c9dcf9d84965e7dfd666252",
+        "sha512": "8f7270fa7e4fbe99a1451fa6ae0221d38a6e48034293f4ff500de6dcfd4c8c992194af74ebe0291e10c8a8140374e80bfebd54629cf818d7254d7c7266b6064b",
+        "dest-filename": "@babel-plugin-transform-named-capturing-groups-regex-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.13.tgz#b4416a2d63b8f7be314f3d349bd55a9c1b5171f7",
-        "sha512": "273608723dd7b58b2964357c8fdba59e830f6599c5fc28f42d4c4f3a347cf41741571fb360923d31d3089546636d70d7fba615792e88ddef28a7ea90dc1601a1",
-        "dest-filename": "@babel-plugin-transform-object-super-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz#9967d89a5c243818e0800fdad89db22c5f514244",
+        "sha512": "c622c3cd634c7caa063a973ab7753e7ad084db24679f748cd3d057a963c864e0692f682f56b05650a9ec271d0afc00e2e45e580b97fc00f15f5abcf6e537651a",
+        "dest-filename": "@babel-plugin-transform-new-target-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.13.0.tgz#8fa7603e3097f9c0b7ca1a4821bc2fb52e9e5007",
-        "sha512": "26df24fe1fe623013624510e6f79544686390bce444dc60f9dbb8027deb3441ce1d571ed4197eceb60a167a10fdb64250bc73b5eaafdabe7b5494e6ab6dc308f",
-        "dest-filename": "@babel-plugin-transform-parameters-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz#ac359cf8d32cf4354d27a46867999490b6c32a94",
+        "sha512": "d782757de890556686bd1c63d968f232e5d2da3b0192007731d48de47b82d86e6746ca5ae512bd08e72cf363f0cb906e19c8dbf9f61a523f7899870e8fbac2bf",
+        "dest-filename": "@babel-plugin-transform-object-super-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.13.tgz#4e6a9e37864d8f1b3bc0e2dce7bf8857db8b1a81",
-        "sha512": "9ea56283055a9fe951fa0f058fc1319745105f69329ad8dc59f30e60cd6f4d810aba37b2bf64a43206b37f6a8d70aee5e120e22b24c0fe71c23ea2f87b6ce8d4",
-        "dest-filename": "@babel-plugin-transform-property-literals-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz#a1721f55b99b736511cb7e0152f61f17688f331f",
+        "sha512": "013dccb9f43bcd9121536870380d756b10671315b42ecceee112ffb40954241b8da116a4fb07a1416f21e8a71739c823638d9f1ed0f1b30b8c84c8c512ebff6b",
+        "dest-filename": "@babel-plugin-transform-parameters-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.13.13.tgz#0208b1d942bf939cd4f7aa5b255d42602aa4a920",
-        "sha512": "48d254e7754cfd28d02f46d987253e7f8909433edb4106a39eb65149a536d61aee1bf356638d4010cf405977975fdd2962bfc2db20264e023ac96dcb94bac051",
-        "dest-filename": "@babel-plugin-transform-react-constant-elements-7.13.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz#2dadac85155436f22c696c4827730e0fe1057a55",
+        "sha512": "cf8146afd34c19da0897546a6af0aa186f99b988df67f8640887ae1fa0e8eed5e64a6d25b35d67615489a8511439225b0da6f9c02ea5444ff0e988d572be87ab",
+        "dest-filename": "@babel-plugin-transform-property-literals-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.1.tgz#1cbcd0c3b1d6648c55374a22fc9b6b7e5341c00d",
-        "sha512": "700cc1f94cc122b7a47d8c722e516a7ff39a813bc72dc5416f9be9a2ece462405c9513eb6a2ca056769fbc0a22a44ad92c8f0036ff04727e84fe6e6a3d70f6eb",
-        "dest-filename": "@babel-plugin-transform-react-display-name-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.16.7.tgz#19e9e4c2df2f6c3e6b3aea11778297d81db8df62",
+        "sha512": "945f9c7ecc938305a4730ef5e49f3c2613182791a9cac60d2e12cfd4f92f9214d137b0777bbe11ff52ac0f1171851a529f45140f72163381af7414763c46db41",
+        "dest-filename": "@babel-plugin-transform-react-constant-elements-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.13.tgz#c28effd771b276f4647411c9733dbb2d2da954bd",
-        "sha512": "329ac4489cc8f4ee559c966b2fb820d4ca5daa6885714bf8d4973b49a87162c34fda40e416a0a5c714d9abed50bf800509a9a6f865cc44340834d9feaabc6688",
-        "dest-filename": "@babel-plugin-transform-react-display-name-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz#7b6d40d232f4c0f550ea348593db3b21e2404340",
+        "sha512": "aa0220f0171981dd06fc2cfdd7a0f9fbd92a5f473b9cf6725da3fc476b4b34de6d932219746e5f13006bc70a65cd29e30b58ef426c8c355c140993dc6c663b3e",
+        "dest-filename": "@babel-plugin-transform-react-display-name-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.17.tgz#f510c0fa7cd7234153539f9a362ced41a5ca1447",
-        "sha512": "04f8d857ce9256e39ab9d161b09475ce3831c4e8490ede891cda03e3c0f158423150200c8d5d72b3a0d8c384836198746f542c4b6bdf200f6dfd9b101ac0ce51",
-        "dest-filename": "@babel-plugin-transform-react-jsx-development-7.12.17.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz#43a00724a3ed2557ed3f276a01a929e6686ac7b8",
+        "sha512": "44cbd05afa656bec72e8c941a4f96b29908c46cd801a21ce187637c51c25d2911e8a6df8f1d0f2c5e1f8c41b0c3db20c86e8deabb8a113bd3678cd84c345a8f8",
+        "dest-filename": "@babel-plugin-transform-react-jsx-development-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.12.13.tgz#422d99d122d592acab9c35ea22a6cfd9bf189f60",
-        "sha512": "157630f7c4d3275db91950829052d95e5675a8672c62a3508550507198f2af07fc14452d55f288a227673bc4b4abe2814290d83539a21a8d609faed5b62d3895",
-        "dest-filename": "@babel-plugin-transform-react-jsx-self-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz#86a6a220552afd0e4e1f0388a68a372be7add0d4",
+        "sha512": "f03d7ac9eeba7f1884f26f3dd30d01a4fa67806f68f4e541072d201f613ed8047ba8c4766694d8244a8bc40b28ae87a7308774a7fc0c5be06573499e0e0bb402",
+        "dest-filename": "@babel-plugin-transform-react-jsx-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.12.13.tgz#051d76126bee5c9a6aa3ba37be2f6c1698856bcb",
-        "sha512": "3b92498ba7f27e287459f0e02095e4b123e118ffc6d1f4297f1632f3bb0373ed6c166b024bac2bdda027fb085bce485b8edab854ca8b45a4b347a22cb21202d1",
-        "dest-filename": "@babel-plugin-transform-react-jsx-source-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.7.tgz#232bfd2f12eb551d6d7d01d13fe3f86b45eb9c67",
+        "sha512": "86cef54e80bdee4dd05b1b30876125ccc1400571ef1a2274d480754db6100c679644a5b3fcc3d44e1e63184c5d1efa2c60aa67256e4f9b74b8f930371725fe18",
+        "dest-filename": "@babel-plugin-transform-react-pure-annotations-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.13.12.tgz#1df5dfaf0f4b784b43e96da6f28d630e775f68b3",
-        "sha512": "8dc108d94a887290aa0795390d1c48974b5010fae823681cbbe83c55322ac4b3b92227688dbe1defbabe7f01ac782bddf1a7ff949f666aca78416cc15c5136c4",
-        "dest-filename": "@babel-plugin-transform-react-jsx-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz#9e7576dc476cb89ccc5096fff7af659243b4adeb",
+        "sha512": "985ee33a01980a44896a027a5c2ba349083eeb10b533beffd372b6a01995256a0518d52d9d524ee161ca264ddd9cf0bc1c2723e310503f51209bc0d68773dbdd",
+        "dest-filename": "@babel-plugin-transform-regenerator-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.12.1.tgz#05d46f0ab4d1339ac59adf20a1462c91b37a1a42",
-        "sha512": "46a79a1e2c19b6985221467923ce4f107d7d2ce4b3c5fb846b3a18effa56012080201b804d0ce94950fe793e8c79b79e653d85e1e48bd2ee2fc3a9f8366d0c8e",
-        "dest-filename": "@babel-plugin-transform-react-pure-annotations-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz#1d798e078f7c5958eec952059c460b220a63f586",
+        "sha512": "290cf30e767d8564018f08b9969639bfdb219a6e88546d14f69075f33bccbb68b81fdd31a53e209aac0f62c9fcace6e269d61ed8cd209a0b2238817903fdabb6",
+        "dest-filename": "@babel-plugin-transform-reserved-words-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz#b628bcc9c85260ac1aeb05b45bde25210194a2f5",
-        "sha512": "9716f6640bd22f22763c47b8ee1a0658f996db6bfb0ad4a5f635bc9a29e05781f6b045ff24e72b023da73ee1968b9e844549b66d4a632b338d02e4fa1c29f610",
-        "dest-filename": "@babel-plugin-transform-regenerator-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.8.tgz#3339368701103edae708f0fba9e4bfb70a3e5872",
+        "sha512": "e8a8365c73c59c86ab370799c66cdb8189e75ac5f1931f56414564dac92c0512fcd25042d51010577c106a05b17421e2607a8f37ea1e9f0348badb6562021b41",
+        "dest-filename": "@babel-plugin-transform-runtime-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.13.tgz#7d9988d4f06e0fe697ea1d9803188aa18b472695",
-        "sha512": "c6150fcc35f164dd507e23b2fc8e6dcb27be4d1cfa940ef3eb1693e022ce8cf44c560d657517f42c7c344c306960be2f1bbf39e7a5ae1ddc8ef688b9526cd906",
-        "dest-filename": "@babel-plugin-transform-reserved-words-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz#e8549ae4afcf8382f711794c0c7b6b934c5fbd2a",
+        "sha512": "85a876f85127a11a004dd21bd3920e5dffb81b35d84eaef94d58489f53dec2285ba72acd594b7625bb9d2903844d6c3a4292def80214a49e4c54b61341b79e52",
+        "dest-filename": "@babel-plugin-transform-shorthand-properties-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz#04b792057eb460389ff6a4198e377614ea1e7ba5",
-        "sha512": "01cfc7e86f45108912dad5ec6632f8440752dcbdd61f1722d2eb009f3ee568f594985886b63eed20048286a2993074d2413418eb10db3aaf95d7fbc8ab742b5a",
-        "dest-filename": "@babel-plugin-transform-runtime-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz#a303e2122f9f12e0105daeedd0f30fb197d8ff44",
+        "sha512": "fa98c9a6002781be772f489a039814ff530b5c921f5dc61ea4b8170777ac5517f87ea9a3f1fd9cc4cdff14a687b199acd3c84540990571c116b88a66e36f535e",
+        "dest-filename": "@babel-plugin-transform-spread-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz#db755732b70c539d504c6390d9ce90fe64aff7ad",
-        "sha512": "c692f8f69a8f9cbb5fd2d565baeaafcd62202c486e3e9673becdb269b50748a44d94ded271853b68c9666af39ec972592a064a41106587cac76ca8890eb6934b",
-        "dest-filename": "@babel-plugin-transform-shorthand-properties-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz#c84741d4f4a38072b9a1e2e3fd56d359552e8660",
+        "sha512": "3496b405dffced05793596734ee646e413c98cb61a75e499f5f3baa0e5282f8890c7ef4412ec3f78433dd92aec4f5f587368e0075bb586c8ea0ed1f4d9cdc3af",
+        "dest-filename": "@babel-plugin-transform-sticky-regex-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.13.0.tgz#84887710e273c1815ace7ae459f6f42a5d31d5fd",
-        "sha512": "57abe48978a38f361e166413af7741c4fb5960b3dc51f637e0379b394dbb8c897633f63c1209b9d87c3cd824a38cfa9de78193949b39c7e091ec778daf6e1c92",
-        "dest-filename": "@babel-plugin-transform-spread-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz#f3d1c45d28967c8e80f53666fc9c3e50618217ab",
+        "sha512": "5706e40c351e7a79488e67cd7835ff574696ad01f642257226dc32995412cc8b450d3a717f2261dc455a4224b4ac837f0aa6cb1abd157069aec324dd66d748b0",
+        "dest-filename": "@babel-plugin-transform-template-literals-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.13.tgz#760ffd936face73f860ae646fb86ee82f3d06d1f",
-        "sha512": "25cdc949a6964fcf9fafb191bd03f4d9f283b189382bf958c16ab7f2bfd419f6b1a3cf5a8ee777db5347dbc29143bc72d586dcd15504e4fcfca6c8cd34352096",
-        "dest-filename": "@babel-plugin-transform-sticky-regex-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz#9cdbe622582c21368bd482b660ba87d5545d4f7e",
+        "sha512": "a76ace8b108a449ce983d241e208e71b88235a459af3d6686149e5f6c9c9d5c5887131ff86fc59a9f3be5a31ba4fc0d106972d1289798f0d4ee6b03c8240a891",
+        "dest-filename": "@babel-plugin-transform-typeof-symbol-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.13.0.tgz#a36049127977ad94438dee7443598d1cefdf409d",
-        "sha512": "77aeee996ea795f9abd627a109c06febd792512c9293512c212f1a4c35f85e8f6a6a3021ea662d725e2426b064197bb164f12056bed155f02f356e9842477833",
-        "dest-filename": "@babel-plugin-transform-template-literals-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz#591ce9b6b83504903fa9dd3652c357c2ba7a1ee0",
+        "sha512": "6c7750f64ed8a410ced9dd0d55f923e750e941cbf023322eb09ee611468c95b66adcab7f538ee3db88a75d91d0e4c0e26290acfa8662c275f229e744f3eabb01",
+        "dest-filename": "@babel-plugin-transform-typescript-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.13.tgz#785dd67a1f2ea579d9c2be722de8c84cb85f5a7f",
-        "sha512": "78abff2e6509a4c9eee27a607efb372e21e126e6b97e8fc2cac10dc5ae396024176702a718240a020f3b6efa2a496d5f153f87037da5d37431b26f28b9363765",
-        "dest-filename": "@babel-plugin-transform-typeof-symbol-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz#da8717de7b3287a2c6d659750c964f302b31ece3",
+        "sha512": "4c05792066a1233df267dfc77efdf94d5db1126fa46810da6500a7d92fe11bdfc26740e4b7126ff5e29f3dcef2602bce611e091b1d61f02fa37123af81a688fd",
+        "dest-filename": "@babel-plugin-transform-unicode-escapes-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.13.0.tgz#4a498e1f3600342d2a9e61f60131018f55774853",
-        "sha512": "7a5404c25bb3694f11f1d6d5b96d90d98f0dce77fb8678ccefe0d209dd782e8e5f17adc2f6a34b6f06586e666bb55f7fc92a52529911a505ef25beb1caee2109",
-        "dest-filename": "@babel-plugin-transform-typescript-7.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz#0f7aa4a501198976e25e82702574c34cfebe9ef2",
+        "sha512": "a02e6d6182b0e7a1ceef929954b43e47f365dc7ae8f647fc886d215e86873fbb630320a9bea06248d7babc6ad99e2d59e8c820994382e80ed53fb0159b0db6e5",
+        "dest-filename": "@babel-plugin-transform-unicode-regex-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.13.tgz#840ced3b816d3b5127dd1d12dcedc5dead1a5e74",
-        "sha512": "d1b1c491dc09fec37f8a40477d298e5cfca937f6de886aa3a3ea38ff92bebf110534f44f7489a1be23da90c286e31f7a97ce5e9a86b467a7037e5b1d06eb196f",
-        "dest-filename": "@babel-plugin-transform-unicode-escapes-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.16.8.tgz#e682fa0bcd1cf49621d64a8956318ddfb9a05af9",
+        "sha512": "f6b34a81509dc076f7cf52256ccc9fb7ac885c878fdf1cfabd6bc668b1eb25386e108a967c76f40cd047f55b938270df75b5038649a4bcc652fd8302b4fec496",
+        "dest-filename": "@babel-preset-env-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.13.tgz#b52521685804e155b1202e83fc188d34bb70f5ac",
-        "sha512": "98347348d63bff3a29c22b0f67990cf572827e1721a8863000a44446d127858b1c641efd5517a4b914a861b374f8a55edf2f3eab587a038b2f5ed3fb37e52808",
-        "dest-filename": "@babel-plugin-transform-unicode-regex-7.12.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.5.tgz#ef939d6e7f268827e1841638dc6ff95515e115d9",
+        "sha512": "039eed87a6111bba11ddcabfcadfd8f3832f1a01347891b617524b84abb21be8c5c4482b77f1c03096ad885b663a266eaf3fb40e4aef6e17822da5797f625f8c",
+        "dest-filename": "@babel-preset-modules-0.1.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.1.tgz#9c7e5ca82a19efc865384bb4989148d2ee5d7ac2",
-        "sha512": "1fc9315e6b4f680193ed3c81bd24a4a124d42ba44787ad52a34e52c846e99abd0c099aec3589fb986333cde62839409d1f3c30eb593c5c17edd936844bec4f2e",
-        "dest-filename": "@babel-preset-env-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.16.7.tgz#4c18150491edc69c183ff818f9f2aecbe5d93852",
+        "sha512": "7d6a7223c50cfc713a0df3c1cc3f0b9e143f39c1fc0204daa9ca8fda718e5c4515f9528147925137d84293d6a2fb3410e7bbed9bda1679782e0423cd523cad80",
+        "dest-filename": "@babel-preset-react-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.13.12.tgz#6dff470478290582ac282fb77780eadf32480237",
-        "sha512": "27312573a8e4dcaa3acee66006d8ce774d697fdc980c4207f0172a56e608b8e9333b00deb286bf373e20228e25046e8af3ad4a4d5f53bc882616e4facad39a00",
-        "dest-filename": "@babel-preset-env-7.13.12.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz#ab114d68bb2020afc069cd51b37ff98a046a70b9",
+        "sha512": "59b5449a05dd232bf307bec042318113260f671fbcb53b0ee745ed7e8cd0ae45bc401dab2c9a47da5831d13470e4426b07139943ec027323d542f4bcb63107a5",
+        "dest-filename": "@babel-preset-typescript-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.4.tgz#362f2b68c662842970fdb5e254ffc8fc1c2e415e",
-        "sha512": "277e8d8709df773a661f8d4cd43ae7924800aa165aaabfcd05d3df43aefb98bce5697a3ea038afd5d7b2083b60021cfca77dbca2d7686f40eeefec601c665b2a",
-        "dest-filename": "@babel-preset-modules-0.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz#ea533d96eda6fdc76b1812248e9fbd0c11d4a1a7",
+        "sha512": "ddf2a1b88092d65333d29948e64b4e13fc84b4144c571a65cd191d9fa989435f7b5e2634267af3615d3e331a33ab7259f12055f4472eae6c355ec19bc0e7fe4a",
+        "dest-filename": "@babel-runtime-corejs3-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.12.1.tgz#7f022b13f55b6dd82f00f16d1c599ae62985358c",
-        "sha512": "7ae084c729870a2d2a07dbb97cac3baef970ec06528f0fcd681f61ec491d4ede7ec8746b5dd8914e1edf906dee04fa4983cd82a8b7e9d4b1cba961920ab69bfa",
-        "dest-filename": "@babel-preset-react-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa",
+        "sha512": "f44f45268c2a02ccadc8e63a2c6fb52aeb9e72444bf9a416fa62af5d15e7b851b2440c9ea493e6128f6f80c7d7500e8ef6edc878476ff4c024a6915c690c2881",
+        "dest-filename": "@babel-runtime-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.13.13.tgz#fa6895a96c50763fe693f9148568458d5a839761",
-        "sha512": "831fad0cb204d3ab118ca26456da59fedde6cc20ce9cf1be8201d91bd95f7d46d7f3ec02ef7f71db461073d577e43a3a640c5a51cfc78551c888ecf3e4cbc398",
-        "dest-filename": "@babel-preset-react-7.13.13.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155",
+        "sha512": "23c8ffc7c90752b6d84535315ebacc6df09aee3c6413bb59adedfdc77923afd86f23cd9c2b515fa8bca0a2d71637991d3c659c2dd58c1e94816afb1ee6d5b0df",
+        "dest-filename": "@babel-template-7.16.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz#86480b483bb97f75036e8864fe404cc782cc311b",
-        "sha512": "84d2bf0e19a824fb24b1d1ee23f455adc130b3b18de5e6a6862dbc2643b9d8ca88c54f19d10a66892390c591d638757b2373f85231d5f7b6b2e1371a98c03a2b",
-        "dest-filename": "@babel-preset-typescript-7.12.1.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.8.tgz#bab2f2b09a5fe8a8d9cad22cbfe3ba1d126fef9c",
+        "sha512": "c5ef87ec996f2ac0d0c1746c0614a7ab5ffef5cf8b9507022b74e7fe5e6c6f1d361d89ecfdc9fb89ba7df91575b0852abbb84a83dd4d5ac807bab3bd768c084d",
+        "dest-filename": "@babel-traverse-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz#14c3f4c85de22ba88e8e86685d13e8861a82fe86",
-        "sha512": "c7f5d8550d61ebce29a75989c0e5780b2bea657a9b73c08cb0c1949c06ee73cd9909dbf553adf0e51494ce00d25d01c6e51a6cfe48a4b07ea0d83e41b9a2b25e",
-        "dest-filename": "@babel-runtime-corejs3-7.13.10.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740",
-        "sha512": "2790087f7bcf8f75305da0336f98f5c4ce160100d7dc43207a617cae308fdd2a16d3d2df44a01740ab7a0a8558976df43fa8967517016e72c30dd9ea5b165208",
-        "dest-filename": "@babel-runtime-7.12.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d",
-        "sha512": "e103e48c9aba36cdd5fd182911a85193e0067cbd1e3ba4471ed4d6a0d36be663b8f46e81e7e5fa77a4c7816100bd3af39d4e716296c095529161cb02821fc093",
-        "dest-filename": "@babel-runtime-7.13.10.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b",
-        "sha512": "3afc0c2ea3579025d2cf59129b9f2c12c36e86a3b1fdf2a99d49ca9c5079bfcb8375ae5b2cd10736028fbe10cde885342c37271d0f742e527443a8e7c8148804",
-        "dest-filename": "@babel-runtime-7.15.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327",
-        "sha512": "ffbc71886039ef1328fcfd8656f744ba6afc38d8453a17e0ab68a12b78757ba4c7ab34c09076e45e0074c48f727937c85281f7fa801e1e1aa6fc8e373936db8c",
-        "dest-filename": "@babel-template-7.12.13.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.13.tgz#39aa9c21aab69f74d948a486dd28a2dbdbf5114d",
-        "sha512": "09b944730997291e9e3f8de84061befb440c4ed0a302c6b77eb52ecc7a222095a9688222f1dc0cc841542685d12f16a01aa08afa300b47020efa8dd1f69fee52",
-        "dest-filename": "@babel-traverse-7.13.13.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d",
-        "sha512": "03669add04e45a8caab19645979e8c2d4b1f9a1eced20378d483ef5c013ffbef288e96f3d764accc3ec9106615767e1ff4ab786a621e8b4eecc05d61e00aa699",
-        "dest-filename": "@babel-types-7.13.14.tgz",
+        "url": "https://registry.yarnpkg.com/@babel/types/-/types-7.16.8.tgz#0ba5da91dd71e0a4e7781a30f22770831062e3c1",
+        "sha512": "b263760d0739b3833b7e7b728c6b7220f6d126feb05b8ad4ffde1f99827b3ca42e6640b4a863075c96e0eac346b75d89995af893961aa6d23f5ed88b2419e622",
+        "dest-filename": "@babel-types-7.16.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -944,23 +902,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a",
-        "sha512": "bfd90884ac237994e1896acb9a3d32d7b096a3275d0122e3f4edb2bdb6646efc3f377ad6398cbdce457aeaeaec02856bd26575e5b2fc834738419504e9c743a1",
-        "dest-filename": "@cnakazawa-watch-1.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7",
-        "sha512": "e5aeb0aa8255ff111d6d134a568e88e213b7563c83abfffcab67fd23a3c102f31eb091c56ae5c3a2b70d0acafd473bec6676968b935809c7f2a8fd507851c56f",
-        "dest-filename": "@csstools-convert-colors-1.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18",
-        "sha512": "8a3e30462ba715f689c6307405dad81c81fc171049a4ec0d3e184072e9e598f757b9d2f5590575aa83fdba7e89b040408101feed45f2ca387483b8d3c572bab6",
-        "dest-filename": "@csstools-normalize.css-10.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-12.0.0.tgz#a9583a75c3f150667771f30b60d9f059473e62c4",
+        "sha512": "334aaac407300ac2157e91504a518de578d75aef25e490d937e7cfb752de5b94997b1413827684be05c063e09eca0470d047a9a561e2d762711125a25ab0744a",
+        "dest-filename": "@csstools-normalize.css-12.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -972,9 +916,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@electron/get/-/get-1.12.4.tgz#a5971113fc1bf8fa12a8789dc20152a7359f06ab",
-        "sha512": "ea7afd0db24f511f57ba3c3acc3df2fab4bde53c88b4454cd0d563b7511e858daf5167c880f8883d51f10af6934b4c6bd81f83471a2f61529bb8e5aa0b7e648e",
-        "dest-filename": "@electron-get-1.12.4.tgz",
+        "url": "https://registry.yarnpkg.com/@electron/get/-/get-1.13.1.tgz#42a0aa62fd1189638bd966e23effaebb16108368",
+        "sha512": "539be45c367d0f05ed90faa5078e6d7d89e760137c3de3e9d73fd70c2ba99d2a5daf14fcfd3842bfd582c0f2dff68aa2486653907e9dc768c350fba85e98e470",
+        "dest-filename": "@electron-get-1.13.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1007,58 +951,37 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547",
-        "sha512": "d993c273eb8d6e357911126bf9a2923d1c1980a776cf5d71d0480bbdbd4f511994ae7f503515c5aa37b42ddab8e783df015c9a258cab0efbc829214fe0d9c1a2",
-        "dest-filename": "@eslint-eslintrc-0.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318",
+        "sha512": "04bc6c9e62b72b23ee9f3e709820a9ab2d187a5128c711a61fbdc8b3e67be2839332d13172392bddd0d1eaabb0ae387562ca40f031fd8275f5a34ebd2a24bd01",
+        "dest-filename": "@eslint-eslintrc-1.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5",
-        "sha512": "403d4f85093eb37d4fd62c6c5f41f44aea2ea69dd5317cc854c4b0a1b47717731250ed98095d01ef1a8b714c3f061f32baf7772e1a72a8b4164cd7119a9e8875",
-        "dest-filename": "@hapi-address-2.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17",
+        "sha512": "81fb5af87f1ace266c9bca596b4be3d3828ee9b8848a2b29a4d800d646c9bc5aeb5aef559bb79a504cbbe83231b2e4da5afb62e5f90956196559ce994c4f8c77",
+        "dest-filename": "@hapi-hoek-9.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a",
-        "sha512": "d5d54d1d3efa52ee4ddde24d4d872fc5e7be8f35f867d95f722a91447094dbb8a16d47188be8927368a697929ed4b5ded52c8908b034fb5e09878b572603a9a4",
-        "dest-filename": "@hapi-bourne-1.3.2.tgz",
+        "url": "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012",
+        "sha512": "7e84192898a0ece6f404c01805f70993c77bed0b4e7bb5a8e28c7b7dfd65418a0d3406fa8f0718d6771da32d9ef70419cef372ece0d90982642bc93399c02702",
+        "dest-filename": "@hapi-topo-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.1.tgz#fde96064ca446dec8c55a8c2f130957b070c6e06",
-        "sha512": "c8dee46dc883f3b5b32c6739e77f539f4b00a63ca218700980abc6f56f02ecefba73baa6a1031f56cd16e1b5f5edeab3e82efc409aaa16bb6074ae4459fe90a3",
-        "dest-filename": "@hapi-hoek-8.5.1.tgz",
+        "url": "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914",
+        "sha512": "5173ae14219cc1c8967243a999f283abf1b28654dff6937f0731bfff1f29f334ce144706b80ebc00d5e17854b4006bf2dea819a8b05490cb3b86acea08a395c0",
+        "dest-filename": "@humanwhocodes-config-array-0.9.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa",
-        "sha512": "08011b587ece22eafa8c43b369a8bcde3ab71662a6bf83e65f52587ecf48ad870611523f9722f51172460a3ede1552746e0e5047c2ccc41944b40fb12a22e917",
-        "dest-filename": "@hapi-hoek-9.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7",
-        "sha512": "7a7b5ff1930e2bcb1cfbc61f78e94cf2909f8376f9f966482817d469a253f14b230003e36abb73c48626dd321b8ef038bbebbef8a6dc5c3dfc93af369d51c301",
-        "dest-filename": "@hapi-joi-15.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29",
-        "sha512": "b406a0d2311c8f01fe3f6aae51f8a977b962582357d85f0dbd88d0a76c2d227b19c67325ca9770d05b4038bc6dbef90ef8649145b98d8bc9bfe72e363d025809",
-        "dest-filename": "@hapi-topo-3.1.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7",
-        "sha512": "b452654f8edd6f490ca959b71f89d06209fa3f0835d064d91dbd69c264a2bf52b892ce9dad03ad7c41796673e392f0becb8fdb50f1caf9b73ced0bcb70bf9633",
-        "dest-filename": "@hapi-topo-5.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45",
+        "sha512": "66740c9cb5787bb843954bf0f07f94f0048bd36492d869fafbd01cdf01862c87bbfa37b601e00ec4f63e8b320f2437c50dbede0e37afd14b3c30ed6215137c84",
+        "dest-filename": "@humanwhocodes-object-schema-1.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1077,72 +1000,72 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/console/-/console-26.6.2.tgz#4e04bc464014358b03ab4937805ee36a0aeb98f2",
-        "sha512": "218d51da2d9a2ec2ebec87774baa76040f3618d5abcade284af1172c029cf8bdb3762f3d752904f310b50bed24a404c6e0984125112740e1fbff399c70cd81d2",
-        "dest-filename": "@jest-console-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/console/-/console-27.4.6.tgz#0742e6787f682b22bdad56f9db2a8a77f6a86107",
+        "sha512": "8dab97c9a7100f7de7e3b038e0aae53957a25c71170ea6a949d7dbf644de90e7211ff3ddd7c90120ed7ec7125044bb86f8b52e963142c131bddab6b8356ed2a4",
+        "dest-filename": "@jest-console-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/core/-/core-26.6.3.tgz#7639fcb3833d748a4656ada54bde193051e45fad",
-        "sha512": "c6f57590a6e17d4a8556e67c0b2a3e24fa62a401c7015de470305fb6276e2bc10809799315d76bcb2dcfecd7d9b7c3efdfbac0f6710904a0829209423edfd78f",
-        "dest-filename": "@jest-core-26.6.3.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/core/-/core-27.4.7.tgz#84eabdf42a25f1fa138272ed229bcf0a1b5e6913",
+        "sha512": "9f5f353eead226454c4be9029481525ff2cbbf0f44c526fee0832d0fa6277f16557abc3d00d62d5b46cfae6d0c26eda97def5263d149f45b50f8c75992b6708e",
+        "dest-filename": "@jest-core-27.4.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/environment/-/environment-26.6.2.tgz#ba364cc72e221e79cc8f0a99555bf5d7577cf92c",
-        "sha512": "9c5cbe7c7976f3352b46c09e301eb55434e1575a554ed944a2405182a3eb713d4936ae3244d2324c77f286de8faad52f63d22cb8b193adb1bc90f5e3499219c0",
-        "dest-filename": "@jest-environment-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/environment/-/environment-27.4.6.tgz#1e92885d64f48c8454df35ed9779fbcf31c56d8b",
+        "sha512": "13ab7e4573df01310419589dafce169e02cd599f1f7c23e4cbc46aa912babb5067d0b2bdd8835ed0c0edb723e5fc93b36aaf760660f339ebaa934f53bccdb64a",
+        "dest-filename": "@jest-environment-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.6.2.tgz#459c329bcf70cee4af4d7e3f3e67848123535aad",
-        "sha512": "d7852579ab6dee377379f2cf60cdca2dc9d497564d8a468aab7e1e9e96f95c6f62f35269a690dbe66b99be89ef2b2ae5edfb441e4292e4be7f781fe4c49f9bbc",
-        "dest-filename": "@jest-fake-timers-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.4.6.tgz#e026ae1671316dbd04a56945be2fa251204324e8",
+        "sha512": "99f69eb61b9817cb1c57c9ed3e98951881d0812d172002dba58da3b7697bc1bfdbbeae10e690cb93810fe03ed202f613d50acf38f55902d6dd18038ec8882cec",
+        "dest-filename": "@jest-fake-timers-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/globals/-/globals-26.6.2.tgz#5b613b78a1aa2655ae908eba638cc96a20df720a",
-        "sha512": "f392ed9e6ec7941fca7ac054b802f043af184d4ef6c3d1f6c56f458d9d5e2f5537961b5e7e38e5e5cd8c8946e95edfe2e8b68f46fa0e149db6c820527d0d0920",
-        "dest-filename": "@jest-globals-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/globals/-/globals-27.4.6.tgz#3f09bed64b0fd7f5f996920258bd4be8f52f060a",
+        "sha512": "9008b030667b531ae03f3bbc62ff6ebd69975f1b32d0672235e8e51ef7cf21f5a44b10a1cefe9b8134b762a0641ae1dc8acfa8b8c148dbaf7a9f6b7e5d821e17",
+        "dest-filename": "@jest-globals-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/reporters/-/reporters-26.6.2.tgz#1f518b99637a5f18307bd3ecf9275f6882a667f6",
-        "sha512": "8766d6e7700f1b81ef90e9d5328f2add05daea971a36dd4793056c38f30157a2c3feaf684a9c4d4986506240278dd323ac9f3a52e61e2e8f9a1190a557aa299f",
-        "dest-filename": "@jest-reporters-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.4.6.tgz#b53dec3a93baf9b00826abf95b932de919d6d8dd",
+        "sha512": "f99a3d815f35475e3e3d2ab8c3379ee060b69a100df62f5aeea80958bf741a9c7b7c76245a94c1bf058d6545ef241c9847db4054175cf15c435aa7c9c8852b21",
+        "dest-filename": "@jest-reporters-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/source-map/-/source-map-26.6.2.tgz#29af5e1e2e324cafccc936f218309f54ab69d535",
-        "sha512": "63061c0b0027366395b19f26af719f9f37570c09782da7a764fe73f86d1cf1bcc2f7f76e80bf33466c59cdda1397821a4b70abc92d6e5a744e2cf1666fa955bc",
-        "dest-filename": "@jest-source-map-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.4.0.tgz#2f0385d0d884fb3e2554e8f71f8fa957af9a74b6",
+        "sha512": "36d8f1f63ccfdba06f85b9bddf3fc029c3d18fff70ae423cf3f80aeb48255c3c75abe21e234adfecbc3673cf4287aa1fa270743a7fe2443ade42e43ab5ef6981",
+        "dest-filename": "@jest-source-map-27.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/test-result/-/test-result-26.6.2.tgz#55da58b62df134576cc95476efa5f7949e3f5f18",
-        "sha512": "e4eec7e5cffb625a23a6160dacad362e50c857618d3d88ac2b01e6d904ca8cd65e1337b309bc18b3db302724afd947cf33267455db2632fee32250ff20a610a5",
-        "dest-filename": "@jest-test-result-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.4.6.tgz#b3df94c3d899c040f602cea296979844f61bdf69",
+        "sha512": "7e2f481a3ddf90eae5326850a9afedf71ba6f2368938e022fe56659ba25749ce79ac9317287c4d0cdd6808fdfd074fc384d39ad8e32ea45f4170a66736d5cc39",
+        "dest-filename": "@jest-test-result-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz#98e8a45100863886d074205e8ffdc5a7eb582b17",
-        "sha512": "6079552233f99df1328e5ad2afcb7f61d35f53fd5712dedce5be0ec5c5c28f24618f32d8bbfaceebdfd61cfb9871b096933f2401e655669d8ddbe20e2cb10f1b",
-        "dest-filename": "@jest-test-sequencer-26.6.3.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.4.6.tgz#447339b8a3d7b5436f50934df30854e442a9d904",
+        "sha512": "dc62fe9ec7fa1353ecc8db09baf3f2233f83c05b82b4176dbcfa66fcb3175640496dd16f418083a5c7184f9eaaab90469e25d6944f359f6aa4d6c7577d979b9f",
+        "dest-filename": "@jest-test-sequencer-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@jest/transform/-/transform-26.6.2.tgz#5ac57c5fa1ad17b2aae83e73e45813894dcf2e4b",
-        "sha512": "13d26385480dcefb90faf5402f6d6f9727f2d7680fd0685acc68090b887aa94b758d27545c6589d707eefd7ed277c7ad4a0c55e28bd3d696fdbf90fa416e1780",
-        "dest-filename": "@jest-transform-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@jest/transform/-/transform-27.4.6.tgz#153621940b1ed500305eacdb31105d415dc30231",
+        "sha512": "f4cb2e7e6242f2de494e9584409d0e70e3805da1f98a86885fab875412c13280993df28a405f84a8ff2400202f099d18d61d99af7b8e71c83cadef83af98f1cb",
+        "dest-filename": "@jest-transform-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1150,6 +1073,13 @@
         "url": "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e",
         "sha512": "7c2e900a9ed2739b17ea0f13bdb9a3e175136f2ae29346a4811cb4df28d76d0681596356184ed21ad264f7c9b437c9f37a00ffed2820ad4962bf1a396b1e0a59",
         "dest-filename": "@jest-types-26.6.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5",
+        "sha512": "8f7e72c343cc4cfa59b14a0e062b87cebd734d8a1a775715204d1a8c48dcac938dc71ae4a3f21118a917c77a2cd0db22e07bb7fb95660db55fab95a11bfa5602",
+        "dest-filename": "@jest-types-27.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1168,37 +1098,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69",
-        "sha512": "df7837a4c264ddb8399d76cbffe098e88d9e243cd90278b8f4f7c99cbe5f8213d38203ef05dfe914d4a026c740816a6db85bbbaaafc446f39816586fb0b4c228",
-        "dest-filename": "@nodelib-fs.scandir-2.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5",
+        "sha512": "beadb806adf29b91c4426d8d282af7c970f08dceef4ec1138510e7929d832bda75baa2d1f831eeae6fcd393a34286ec760753b7a9a4a663dcccaa62e3017fada",
+        "dest-filename": "@nodelib-fs.scandir-2.1.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655",
-        "sha512": "218947240d1c96ddbe560edb71cabe4f345d26fbf5f5cd8836a052b2838ba758deef18edafb276ebe59747bd8c09dbd4f6ad6a4f32160df84c7fe0d1bd024ae1",
-        "dest-filename": "@nodelib-fs.stat-2.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b",
+        "sha512": "46484f3e9db3aea0c0400ff68cd867ced70f025bfae17761229edaef8e78039a2f23b06e93182decc5fbb9dc00bb7ce0d437293d4d2bcf7555d5279aaaf638f8",
+        "dest-filename": "@nodelib-fs.stat-2.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063",
-        "sha512": "f01ae86aceaf4ed5b81885d30070e8137da19cdd8ce729200a95866ee5c7435e6f10caabdb7a41efa7bf199718b1908700bbf9d24b5ddb8aa11322abeb006da3",
-        "dest-filename": "@nodelib-fs.walk-1.2.6.tgz",
+        "url": "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a",
+        "sha512": "a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a",
+        "dest-filename": "@nodelib-fs.walk-1.2.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674",
-        "sha512": "d5251ffc28361b3183c9a7f5e5a47d4adf535a56fe5ef6d95d6a43c7c60ab3b30bccc1ff0427a8a6ffb2f6fcebce091fca4086b963a54aede66618f6f8541cae",
-        "dest-filename": "@npmcli-move-file-1.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766",
-        "sha512": "6ebe50c2f87c0f6390a925e977583fc6a5ca9cad2bf89cfaa952816d69a951cadb18ec54adfdfd579a19d7cefad3ce021a7d7cb8c751e6ebcfa81bfd52ab418d",
-        "dest-filename": "@pmmmwh-react-refresh-webpack-plugin-0.4.3.tgz",
+        "url": "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99",
+        "sha512": "cd96d97874039e84e5b76005f9d8904f4c2c497a6f5a2688399c0145d96d345846d7e237a33c9ac3b53f9c1894c322740fecf0757a741376d63a5dfc020d8133",
+        "dest-filename": "@pmmmwh-react-refresh-webpack-plugin-0.5.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1217,9 +1140,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca",
-        "sha512": "471b522f75e6753004d9bcb17a460b9f1fbdf241143ab3c717f2915632c7f831081f2ea48c8c3b608350ce7f8d5e21ff353ad02c0c18b3419607e72c5b2800f5",
-        "dest-filename": "@rollup-plugin-node-resolve-7.1.3.tgz",
+        "url": "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879",
+        "sha512": "f6e202f0764e9d52eb2c7c5acaafcf4f3c3eb92db9135e0a3d4061e64b45fb5f0c8e8e722b44e830cc7a7a9634b848248f0270d1a056e31da1a2b61787c8ee5b",
+        "dest-filename": "@rollup-plugin-babel-5.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz#82aa59397a29cd4e13248b106e6a4a1880362a60",
+        "sha512": "c9cda7e378dca95c86136b2a579fd80a6a1ccbd02b8d500ffc1797c93b400d30415fa5747b950cab03bc09d4349338dbeb3bb93f5a8ccec49c08c46f13d3a556",
+        "dest-filename": "@rollup-plugin-node-resolve-11.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1238,6 +1168,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz#7f698254aadf921e48dda8c0a6b304026b8a9323",
+        "sha512": "24ba3e639f76433204faaec3976a4c52db78abc48a608e630eb671ae8cc44319c654ec9813e1962bd78b9304da78df430dcb65691010dd3066cd9d6a74b137d0",
+        "dest-filename": "@rushstack-eslint-patch-1.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/@segment/react-tiny-virtual-list/-/react-tiny-virtual-list-2.2.1.tgz#658da8a93cfb83537235c89307818d6f1741aeb3",
         "sha512": "1b4d5bf43aec40b17ef32151cb225e641664cdb16ea882c6f42ed21454be1ad4c56e3769ae41edd022f4ae208f3997ded595e24fccfc31a2a859f361adf52385",
         "dest-filename": "@segment-react-tiny-virtual-list-2.2.1.tgz",
@@ -1245,9 +1182,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.1.tgz#9e321e74310963fdf8eebfbee09c7bd69972de4d",
-        "sha512": "f88e5a690af79b438098cafb450ddf47dcf1e79b1e8c4611d811496b12fecd3dd5336eb5d57d121ef3d621b0140595539ff63360a6d5f20276a13fd010b9277d",
-        "dest-filename": "@sideway-address-4.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27",
+        "sha512": "f2770452d9a74ec3262fbcf560f078ee43d4abb2e929624d14fb11cc78886a3182e6e5e55869fe0269183dc1cd97c4b8b5c106c7e7273919cd61ac36c2f2fe2d",
+        "dest-filename": "@sideway-address-4.1.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1287,16 +1224,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b",
-        "sha512": "b2bbb077ce9124776c55ffc0b41a228c3994a89a7707a845fc3182db70be25a7a09c31da6727b00a3a15193760dc9d2ecf766cecd9c84f4e4e04e98c2fbda543",
-        "dest-filename": "@sinonjs-commons-1.8.2.tgz",
+        "url": "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d",
+        "sha512": "c6435c2c09ffc19697d7844f9708b370a89c0e4f46dc5f26da75372fb5249b9cc1813c224f4c2ca05007c7d26ae7a7c9035cffeee286b4246ed7ab0e5022c81d",
+        "dest-filename": "@sinonjs-commons-1.8.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40",
-        "sha512": "3193d4c6b985b9b237e974b50c8dea988d1874dd6092ceb626d159bf147aee58e348d09e2ba534f19c789ac116397ba87e0a94b7accf1d28b51fd7db8d1fcd44",
-        "dest-filename": "@sinonjs-fake-timers-6.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz#3fdc2b6cb58935b21bfb8d1625eb1300484316e7",
+        "sha512": "3803c9500b6078836187f4c0954203e104ece773639bbc7375d695944b3f497c20b620f5b56db6cc007f5b5c1da9fae99a292069643d170e96b3e86c8919b956",
+        "dest-filename": "@sinonjs-fake-timers-8.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1308,9 +1245,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.2.tgz#e6786b6af5799f82f7ab3a82e53f6182d2b91a58",
-        "sha512": "c8130faa6775c84268ff6f343c0324c9c86e6802f243d2e46f9ab5724de68c9ac5b84a1b21f86743827799bbc1a084a647749631657e70607f23494241e7bbf4",
-        "dest-filename": "@surma-rollup-plugin-off-main-thread-1.4.2.tgz",
+        "url": "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz#ee34985952ca21558ab0d952f00298ad2190c053",
+        "sha512": "951f2affd5bb859a4c5b078d880294ecd41eac19f34102ef8bcaa74c353f7f122d3e1b5954c6cf57795b0b08e12253417bd05baf957e287b21bd6995486f5cc5",
+        "dest-filename": "@surma-rollup-plugin-off-main-thread-2.2.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1420,51 +1357,86 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3",
-        "sha512": "5cee8834f6d90b1769ae5fbda9afc001b14538ccf3c2a631a633e02c80ab303e82d850b0eaa7c938f70193a26aa8f2d2699fd0c7ceea9f8ae93e63ccc1a00aeb",
-        "dest-filename": "@tokenizer-token-0.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276",
+        "sha512": "3af8c5fb3e752f7a2fd0ec8053476ecec62ebced353c7ef1e2de83271fa0b9a8604e704792125d1bbb2841e4d214b58ddde7e71f289b67867c97612e5b024ddc",
+        "dest-filename": "@tokenizer-token-0.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a",
-        "sha512": "ffe0913d7a410e9a3644af42ebc3776f670ebced027f907d68f8a31eca034131e2be719239b74e17605140e623a235930f2ea742f3239aa4572311f9e558f1c4",
-        "dest-filename": "@types-anymatch-1.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82",
+        "sha512": "45bcc9be5373991ab97373b4f548a97ae5e7a38b40d4513a8a43a3c592b4b6ec55bf7e35da5eb8979b755b9a63e3eac9abdbe9926fe4c22474eda6579ec28fc7",
+        "dest-filename": "@tootallnate-once-1.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402",
-        "sha512": "cc6649cf3054543a3f795e8a81b1347f4648edd227118be8d7645bef4b8d403b210b74a444c6faee36b41a0447660017dd96baae169696f6c33bcaeb1b201bd6",
-        "dest-filename": "@types-babel__core-7.1.14.tgz",
+        "url": "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad",
+        "sha512": "2fbcfd060acd11c632518b45f876847e24b979b921f635ea6eccf3ee90b485104f69ab55d178d20f7f9e1eba6a15e9907e0c22145d103c86ab9c88a12039fb38",
+        "dest-filename": "@trysound-sax-0.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.2.tgz#f3d71178e187858f7c45e30380f8f1b7415a12d8",
-        "sha512": "31d4899c18e5f9b77090bb24677346169f587171b1e6080ba5040faad81a91586c58ad214ed358863a592e55904ef8864ef17c6adf81be58b78d5edf68f76079",
-        "dest-filename": "@types-babel__generator-7.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-4.5.4.tgz#e2ab67f8a1f175bcc7fa2122634a1ac3804d498c",
+        "sha512": "88394b91d837b028d448d768502b1833f49785e1eb7711ec47a9ac2246c50d6e2957a8074ccc20ffcb5efe968bb72c038c62f84b80720dd50a03745b7dd057d2",
+        "dest-filename": "@tsd-typescript-4.5.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.0.tgz#0c888dd70b3ee9eebb6e4f200e809da0076262be",
-        "sha512": "3533c4af1e3f1623c2192707edfa0fcabfbfd439339278beac78981c7a138efc28bbb010cc990d783eb403d097472f9910dd81d5b8209a44cc0836fe32fe64f8",
-        "dest-filename": "@types-babel__template-7.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.18.tgz#1a29abcc411a9c05e2094c98f9a1b7da6cdf49f8",
+        "sha512": "4bbba70e39bf0bbcf603647d3737ca08ad48f810002c3b71126b09070941dc4ccd7dbf76f729232fefb508af4b3bef84229d9f42b0bc3be0708cabf3e94783c9",
+        "dest-filename": "@types-babel__core-7.1.18.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.11.1.tgz#654f6c4f67568e24c23b367e947098c6206fa639",
-        "sha512": "56cd219b4bcf6a13cc622f6d0e3b4feba965b9f80edd24f5e965da493b4318497d71ec009770226e6c56c3a4c834ea873d3f73d2e0012806234fd8cd4a0e27a7",
-        "dest-filename": "@types-babel__traverse-7.11.1.tgz",
+        "url": "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.4.tgz#1f20ce4c5b1990b37900b63f050182d28c2439b7",
+        "sha512": "b4591c881f63d8aef9e72ad300bc43e3831c3ab93e81fa48a6f0b7b311e345ac23e8f7e7431aec7b80a5ab9cbf46af86de6ac1bab31ac7f946f109f6b7d992b2",
+        "dest-filename": "@types-babel__generator-7.6.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd",
-        "sha512": "435cb9d7919c39d4c781a81a5458479c8150dfcca0b3f926c5d369be9a2efab688f543b76197070e780149829092570a96f03b8ae42598829bcef9b170e13d09",
-        "dest-filename": "@types-debug-4.1.5.tgz",
+        "url": "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.1.tgz#3d1a48fd9d6c0edfd56f2ff578daed48f36c8969",
+        "sha512": "6b304529e997ea4320e48a3efeb7464f47641ab79ba14551d02766ddfcfd4095a96901894505e5ec2fba84e4c265c32597b285c8442981b608da51ddb12e14ee",
+        "dest-filename": "@types-babel__template-7.4.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.14.2.tgz#ffcd470bbb3f8bf30481678fb5502278ca833a43",
+        "sha512": "2b6c1a5dd5c18b6df4d9751d707711d6309e5342cbe130fd1d1b3f824d0dd97beb86df86fc17c96b840e6c14197e131dc620a957708e97935fab8b8a4de4e724",
+        "dest-filename": "@types-babel__traverse-7.14.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0",
+        "sha512": "00b6289deea99ba426c19a0081ec8d92c71c4fd438016650e8fbdfc11dfb193eabe855943e0baaeac52634648c5765abefad68428071c0619ae83479a350c2f6",
+        "dest-filename": "@types-body-parser-1.19.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/bonjour/-/bonjour-3.5.10.tgz#0f6aadfe00ea414edc86f5d106357cda9701e275",
+        "sha512": "a7b89e9d13224b8d4dbb6fe281b271c4b0d6ad26745b133c51080278ef4a868545edc395164acab220ebd44b092256bcbd5de81048c6733d758dce728a687367",
+        "dest-filename": "@types-bonjour-3.5.10.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae",
+        "sha512": "87c4096bcc526f5583e1fa4a0437004c33465e08458faff7191586e9d86645cbb4457d546dab2eaf652fc7969e13095fd0cc1b9440b66cccf33109edc67c3f0b",
+        "dest-filename": "@types-connect-history-api-fallback-1.3.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1",
+        "sha512": "71d798cafe0a5a8120a412124f15afa98b15cb8e380cea9e8621777ccde77b5d00989eb6452c8d9149f13095c7416450417d9e47de26e72d486720f006357d15",
+        "dest-filename": "@types-connect-3.4.35.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1476,9 +1448,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.8.tgz#45cd802380fcc352e5680e1781d43c50916f12ee",
-        "sha512": "4532af06c7f3d13f0228e19931fba5b833723051e7bb996f36be21584b107875c7e85726203228ccec96321dfa9cb18cc157795053570b6c73b40f25967db631",
-        "dest-filename": "@types-eslint-7.2.8.tgz",
+        "url": "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224",
+        "sha512": "3c1de5772adc9c089c4f7e5358fb3921cc0a0fc4b7df71cc69ad9556fe3ec1dbde6c99235ae5bfc444a807c23045ca20f0761561a99bd60fd1df542fe41c74de",
+        "dest-filename": "@types-eslint-scope-3.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.29.0.tgz#e56ddc8e542815272720bb0b4ccc2aff9c3e1c78",
+        "sha512": "54d72f8a86031fcfc5c5a7932a4338fd3893c2dea9055f44dce7c69af6b0f2d3e5d2bac7089e0b975e47453fa93221407ff30b42f0330bee91cd43042fd09e9e",
+        "dest-filename": "@types-eslint-7.29.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.2.2.tgz#b64dbdb64b1957cfc8a698c68297fcf8983e94c7",
+        "sha512": "9d0c6007cfd283e40a86757c7b45b33e9c632064f7b6e2430f3c9b9038bc22d13f2204e51e8d3b534b216888f385cbd0c65abd483444e3696c276deebc4809d8",
+        "dest-filename": "@types-eslint-8.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1490,9 +1476,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4",
-        "sha512": "739722474ea32bcbbd06cb6b989c8ef7b9be92526bae109ff6edeb2eedc31002418abc51a920af0d0a182a6c6e630408e526428405aefadabda1594646eccf02",
-        "dest-filename": "@types-estree-0.0.47.tgz",
+        "url": "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83",
+        "sha512": "0ba379b36645b6e6518f9e24dbfcf24613438c9c3071588033735b9bcce30696ea01d674d26af4085c6f48a78ef18fded3759514ba5031d1d855f51de9207e1f",
+        "dest-filename": "@types-estree-0.0.50.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8",
+        "sha512": "3f5049004016dc4d8325496482ae2d38bdd1c8cba7a165ea6d20b2816a396485938d480dd589da5d65b855697fa1cf2fb3f5e86226c418128fd2e6721780078a",
+        "dest-filename": "@types-express-serve-static-core-4.17.28.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034",
+        "sha512": "e9b4994cf6932000b19f8f25e74491f9ac60aea9baa97148c6b74029a1ba3da264dfecee52bdf98419604fbbce98972e9be38468804bb4757faa5a0400521378",
+        "dest-filename": "@types-express-4.17.13.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1504,9 +1504,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183",
-        "sha512": "48461e1802102105fc34de8b0caa6b2e36eb77974044ce445ec77c188fc0e65d1aa582357c631680f1d27b864a2f87a8ce503223e768504f576d84b8c42910d7",
-        "dest-filename": "@types-glob-7.1.3.tgz",
+        "url": "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb",
+        "sha512": "654c5bcca97421f2482d34bab7b8a9e5f41033f2774c962e6c39b79cc6e0b9b34d612eb6797794a682d40bcffb7c93621581d3ac63d09fb86ca435332075f750",
+        "dest-filename": "@types-glob-7.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1518,23 +1518,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.1.tgz#b16872f2a6144c7025f296fb9636a667ebb79cd9",
-        "sha512": "be2c30ac1fbac46cf0f86d5e5a917d81e5777e7b03817a871be72a8221ebbd07c3516e61ce10b257b4b2dd427185f44506c824cb64925b7dea8bf62b2248d7e5",
-        "dest-filename": "@types-hast-2.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc",
+        "sha512": "c0b126d10bdaa1ac040e84d1c334d7a786f88e9c22243bd1e4a327167568766dec72e7d3941396443e8dd4e05ff5364c86394db127dc3b957eec0178f95cbef6",
+        "dest-filename": "@types-hast-2.3.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50",
-        "sha512": "822025670b2d29b9af324d4e3bb5974a3e0e67491e5c0725d9342ae0b5878a23c7d81c9a1fb59e5339e0f907a3f143f1c6ffbc9514eea2ea3489a34306ecc804",
-        "dest-filename": "@types-html-minifier-terser-5.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35",
+        "sha512": "a21ffa6f20cf9cbd7378d5c5ac35c52f266392bd4cb011baebb20cefdd9c69fd4bd943ce38c7fae4d1738d41ff96dc9fc230067ecd6bb17d5e7ed2b48c2fca22",
+        "dest-filename": "@types-html-minifier-terser-6.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762",
-        "sha512": "b33ee22eabd5520d6021e7413af964c4f95cf3fb95cf24b93b01b3d5c2a35f3925dc5a4bdda97472b53c6065355a81e4c67d16c5bc39b728ba86fcc928dcc5b3",
-        "dest-filename": "@types-istanbul-lib-coverage-2.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.8.tgz#968c66903e7e42b483608030ee85800f22d03f55",
+        "sha512": "e643cb1b904aa56624c3f2d53865a98aade7115ab188ddf6ad3808e774a4d76ff11c5436ac6dde848f483be3b75b642829ec81f7674992891af12526e815f5a4",
+        "dest-filename": "@types-http-proxy-1.17.8.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44",
+        "sha512": "cff413d573782b8298bac952db793adb20c80cbc0b164cf13ae329943b4e6f3d3ecbb56a24268eda8f923f01c2bcb15987bc5acefbe8a2bdad03f84fcfd79eee",
+        "dest-filename": "@types-istanbul-lib-coverage-2.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1546,16 +1553,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821",
-        "sha512": "9f028d6ef9f0276fe69dd13d22d3ffcdcd930b3c3abaea1d9c5e041d8583fa00900d506e4502f95336d90f4fdecf2d622ac154d994220ea83833d74de3ec1980",
-        "dest-filename": "@types-istanbul-reports-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz#9153fe98bba2bd565a63add9436d6f0d7f8468ff",
+        "sha512": "737980644b8ad25bc1a7cb66b8bef85d12a7d7ecb675cc0e5291fbc785ab17a824d462208a5b8346031842dc36385701bc025696de80494ded4aac69d14bb403",
+        "dest-filename": "@types-istanbul-reports-3.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6",
-        "sha512": "79e5b05a396ac6f071738a10764b9e5b9385fe0b5f49c78a9383a73801a5512c12fe588146d669a5b26ecf562481badb7c63a87811ee9fd7cebd79e3370ad23b",
-        "dest-filename": "@types-jest-26.0.22.tgz",
+        "url": "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a",
+        "sha512": "13f5f95626fc056a99351943c63f6f61786c0f03d86cf20da8a17d06c9d2a289f8450d03f66a04b8b0fcb71832ca914b1fb278f8b868f4daff73c1f4162fb5ef",
+        "dest-filename": "@types-jest-26.0.24.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1567,9 +1574,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad",
-        "sha512": "731585415b1e066e8ef466f0d4859bf2be8e4b83a14adde13d92e4140a4b8ccf1311744e06e4062c01f68b6819a5c5dd2c122ba57b930e11fb55b9b589798d18",
-        "dest-filename": "@types-json-schema-7.0.7.tgz",
+        "url": "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d",
+        "sha512": "a9c517b9e9ad12ef84e7065224737151778266101f5ca438d43f9db97f9560f75eef1c84559722fbfa172892f5ded9d1b3d951da9af87e8779f464fafd7d7fc9",
+        "dest-filename": "@types-json-schema-7.0.9.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1581,9 +1588,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21",
-        "sha512": "d73f24e30cc59cd8d52bfb65c6fad6b8ae5632dea6c9d5963fbfb3bc7e5e15ea78a23f9492b7e225346d8c27815cda70680fc562aaad6f8fd04b889a9c5a4844",
-        "dest-filename": "@types-minimatch-3.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a",
+        "sha512": "6004f1571811a8d1fa9c7108b2f83a93606873524723d65b1f9896145bff31391c873ddbd627860dae53d1af51ce735d2342a155b75b59237e2965ab4194714f",
+        "dest-filename": "@types-mime-1.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40",
+        "sha512": "2a5cfde3d874d86cf6b9908c1b00d44834b56019537430e06d61e2fbcd65dbdb5000b52dbf3e2b0188b9ba85611392da828aba0dea805256eb1ef5bf9970e075",
+        "dest-filename": "@types-minimatch-3.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c",
+        "sha512": "8e1b8a2c846b86f08f2eac0f731e8836a98a7a2039116aec08e3e1ae5152adbae653864c3e38f9525fe82c23033bdf17454230566efcc480b3e043c27a4b7379",
+        "dest-filename": "@types-minimist-1.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1595,23 +1616,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8",
-        "sha512": "8162fc554920f1545a0805201bd5a685e7cca8798c6e5c5edab569305f3a9d963ff99cac53e064029fb7733d37022c560d24b3d24b39597e7dc8086ffdc0f014",
-        "dest-filename": "@types-node-12.20.7.tgz",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-12.20.41.tgz#81d7734c5257da9f04354bd9084a6ebbdd5198a5",
+        "sha512": "7fac4eaae71b0e2ac6ecb3b379da6fce33f7513987b6d468bb7328b31def2fdc2bf402101a170f8159ea6bc8a1a59627c72335af178d0af4f2ba43ca66dab5d1",
+        "dest-filename": "@types-node-12.20.41.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e",
-        "sha512": "5d89818b2fa884e4782e1e63137efd7d5d8853ee899f8839a804a29e18ad7f23bbd5bfec0a8e8c2ac30b179b5ced97f6084f21562550c984a86c93647bc3af53",
-        "dest-filename": "@types-node-14.14.37.tgz",
+        "url": "https://registry.yarnpkg.com/@types/node/-/node-17.0.8.tgz#50d680c8a8a78fe30abe6906453b21ad8ab0ad7b",
+        "sha512": "6287e433a7c6bf880326aefc8388f498cb86324655c590e0b54d0945dc7a1608890c6fb47d8d06295a25395f16a9598484b097910463c0374ac8fc49a7fbae72",
+        "dest-filename": "@types-node-17.0.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e",
-        "sha512": "7f98f96ff19fef52fe75bab12294386765a5988fe63c9d1f3a418698582d6fab00bbdec43dccf36d2dffb492b199c6038f9e4e5fab2cab00c058e1c860344318",
-        "dest-filename": "@types-normalize-package-data-2.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301",
+        "sha512": "1a3edc23bcfef7c336f364ea9a9d8ae4422ca28b941336c1261410cc31378d221193aafd82ccf4a14a24a88511e2ed51ddd307a34a431cceec34e1f286e972a7",
+        "dest-filename": "@types-normalize-package-data-2.4.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -1630,338 +1651,324 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0",
-        "sha512": "3e28d1086fcadecdf0d567baca750a77111ce4072eb87dcd0663033fcbaf295a7a5f8dd463b350953cdccda9173f70c947417875f3502068d4d9c51e458b3600",
-        "dest-filename": "@types-prettier-2.2.3.tgz",
+        "url": "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf",
+        "sha512": "4334ae64c06e1b9bbc1ea633d35aad31d83f25f72d967be3d73fe56272035ecfe0a25c70d1fc6d4401ddf4aaf38d1ed8c73d6a55e234d28d2488edcf995749f7",
+        "dest-filename": "@types-prettier-2.4.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7",
-        "sha512": "29f44bdcfb879aa40b386fb6b46a513b6e82b60f82ab5134d43d8332b88a1004c78162df78d0e6abd7b6f50f56224cb4750dcd3e47759b3607f0b9bddfa67dab",
-        "dest-filename": "@types-prop-types-15.7.3.tgz",
+        "url": "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11",
+        "sha512": "ad9e5dac2fe35a3ac0aeb4bc051e9222be1c5a95b4f5135362df40319a37270c227fe89a71702a8158e6d01d01bff4b58e10d7287a9154d09b002909f3d4409d",
+        "dest-filename": "@types-prop-types-15.7.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24",
-        "sha512": "d477036acf12123e33d5673af7ab47e7a1bc3a545a1ffb2a64eca734d07e1c5d1639e5cf6b14ed6d8cc9636a047e25318d22a38422abf8cbd1edd0877047a5ba",
-        "dest-filename": "@types-q-1.5.4.tgz",
+        "url": "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df",
+        "sha512": "2f6f23d857097d264e9cbd560630d8a76bd41c2788165c9823fe771300ffaca50143b32d5147db4168b22891a9727bf8fd682b856b052ab70fb2d700b7f274b5",
+        "dest-filename": "@types-q-1.5.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.2.tgz#38890fd9db68bf1f2252b99a942998dc7877c5b3",
-        "sha512": "2a26c358bea7b21b8e2747eef2597b42757f2d54e8dcfcd0f5a08f9d15183df5fb799a211f02c874d1e3ee97ed6a7444cc734fe3f9c96bca1e33bdee4a26af31",
-        "dest-filename": "@types-react-transition-group-4.4.2.tgz",
+        "url": "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb",
+        "sha512": "1466b517ad854f4f6a72bb9e040eaa613ac93d50f36a1f5afb8f77fa8d8f097b1eb161c89f6ec6f7c4ec48cb3758f35b648123e3e5497fab1a485a6f0fedd9b3",
+        "dest-filename": "@types-qs-6.9.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/react/-/react-16.14.5.tgz#2c39b5cadefaf4829818f9219e5e093325979f4d",
-        "sha512": "61146ff4335985a55355187d5a69a2b7b63450584456a5ea092c37b9acd158cc5adb1f39856419e41376e22ec65d96da72568b5c47287447881ec8c103c78033",
-        "dest-filename": "@types-react-16.14.5.tgz",
+        "url": "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc",
+        "sha512": "10486c2ec0fa52c0ccd7216102fcb40a3afa5709a9316a850426fdc34ef056e805ef0f677da8f12ee5669e04c8a604bab2f0a79ba55ac3e3198680c22a739fb3",
+        "dest-filename": "@types-range-parser-1.2.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/react/-/react-17.0.19.tgz#8f2a85e8180a43b57966b237d26a29481dacc991",
-        "sha512": "b17d478ac741d7f6444a2c4c4c69ccc47f530def1293bd3def7e1f110673095ff8952bbd90908f6e8d8f6d346864cfb9dcfa743f5d21615c91794b9e1b0522e0",
-        "dest-filename": "@types-react-17.0.19.tgz",
+        "url": "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e",
+        "sha512": "ee000fcfb6a754ae71cdb7905bdc0504383b1bef9a3cb00563441a48c3a8bbdac96696ee239f1602e26b82efaa47dda5eb582b9670947bb0055fc2866a1020ba",
+        "dest-filename": "@types-react-transition-group-4.4.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194",
-        "sha512": "6ae0293da25fdcd3df7b5f214a8264a7c11b6737abd884a4ee8f26082dccf617bf6b4e3e81b305f7b364a43d92f2b88c1af9b804c448e7dfd265049a2d32a9b1",
-        "dest-filename": "@types-resolve-0.0.8.tgz",
+        "url": "https://registry.yarnpkg.com/@types/react/-/react-16.14.21.tgz#35199b21a278355ec7a3c40003bd6a334bd4ae4a",
+        "sha512": "ad8e03ccf28aff86a88725a20d11d2d9fa2d379ae10522bafebcf55f7ecaccd9daf47272aad68601babd7d5b6dac43d6179cb0a5f20fd484cbf178b64199fa12",
+        "dest-filename": "@types-react-16.14.21.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275",
-        "sha512": "11a0b16da9d57b2c4345340191d2dbdc1be5fc72bb3c12ba5098ec4a2c41d221caa16c44e6ebb643f0e0b693a13c8a23374665d7086f39decfa07b363f4b3978",
-        "dest-filename": "@types-scheduler-0.16.1.tgz",
+        "url": "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd",
+        "sha512": "488f765f5200f853273f7a8ce66e1045e96e5f385c9a8be16672cd9b7a72790968a22d36a88eec2e27a9118a93ebbf2e362c9cdb95df0aac51105a72dd6ed885",
+        "dest-filename": "@types-react-17.0.38.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9",
-        "sha512": "2b92beca697c2d3a3d6d6248feb1027c83eb1a0c5da5e35b8fe779de5c0de108d6d4c0b09648549acfa0b5dce2813794c81af4f7ebbc070388637317bc775cb0",
-        "dest-filename": "@types-source-list-map-0.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6",
+        "sha512": "cb2ec7bb34218f47611a90fc44b5d26561242ec57d89bbf1be2e84889ddb92a2c03b5446a3459b916422c29465485ca64c9473d1dde4e4b337924c7c02b0db2f",
+        "dest-filename": "@types-resolve-1.17.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff",
-        "sha512": "44926baf2498ec0f216afaa918e6ce0785bdd905ca268eb7fe314b2e0a6f3adb0652a6d067d49b825df928c9b50e30ba8fb02f9a65366c89e8fb723211a7a66b",
-        "dest-filename": "@types-stack-utils-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065",
+        "sha512": "c680e53364b8a2bb5ac1258e458aac754fb6af1761e0b456f72b5cdf3993dfb44829087a207c8ac30b4a84a8acf5a87ca25d3b0c2919c4fb7c041bcf8c2eafe2",
+        "dest-filename": "@types-retry-0.12.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4",
-        "sha512": "d15069ad5a9f8050fb1216f6bddf0b87d4c6de33fdf20bebf2b81e850ab3ced64d23ba3ccd2f007788f266778a10ba61a6e136d760fc27bd0b9d23504b23ba6d",
-        "dest-filename": "@types-tapable-1.0.7.tgz",
+        "url": "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39",
+        "sha512": "869a501010e69708450172895f62a758b62ee7231f8bdd726b33dbda5fa56c98b05bec1da3580d79103edd180d48edfd5985f67ae7b2e35284c27a9eb14d897b",
+        "dest-filename": "@types-scheduler-0.16.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.0.tgz#1cad8df1fb0b143c5aba08de5712ea9d1ff71124",
-        "sha512": "10692b243e54cbe3e0d0d511f2e0386c9e5631f963c9a7741beefce2f2c2354903f90c0e25751b0581315df5467fb62dcb3750a772ff5cc61c96207df3b90be5",
-        "dest-filename": "@types-uglify-js-3.13.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278",
+        "sha512": "77f1ecde7583c4d2f6c4073398e559363f76619092e911b17c13e32b3baefd78ab0a05dda4a11bf3c75835bad81a29ede885562cd3feca89f0540b910b44f60e",
+        "dest-filename": "@types-serve-index-1.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e",
-        "sha512": "16f52ea6e337ae546c46d08df9f0ee76d9b2b463ba88726eb91292d52b34a46e73f285f4762344c3de1410bee18036e937de2b81a2b947bb169ba46b4a466e01",
-        "dest-filename": "@types-unist-2.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9",
+        "sha512": "9c2907188e30ed980074d92b12ed1bbfee31355fd70ea5be0f27649de6cc390c24a431b1f06f874e58fb47b00123c8bc9cac55c34c2d28f8b50fe94f3a487861",
+        "dest-filename": "@types-serve-static-1.13.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.4.tgz#805c0612b3a0c124cf99f517364142946b74ba3b",
-        "sha512": "3a325dab1e9095bc99c3d2d284fc115be2a689e81e837796348e3531040a686def8dd5362fd4911259ed339d47987058d5cbbb8b3c5027594c622a108775cc06",
-        "dest-filename": "@types-verror-1.10.4.tgz",
+        "url": "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.33.tgz#570d3a0b99ac995360e3136fd6045113b1bd236f",
+        "sha512": "7f428411ed3936f5276adf9ba0f4d9d1d81a2d9e127d2a2e5d482fe67a1489e7c6d9a8e02a39844e8f59272baab25edd7e5d9a1e52c9522922e81e196257628b",
+        "dest-filename": "@types-sockjs-0.3.33.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz#8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10",
-        "sha512": "2d79ffa1822905eb9c80fd442096ca436ff8666a6f465f9d96b15d5fbfbde12291515dc4bf2dc5b1f319637d7cbc68645944b930f86d38cdf0d7f84238039772",
-        "dest-filename": "@types-webpack-sources-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c",
+        "sha512": "1e5db5f7f053e5f2c06b3e8d0e44ae8736accb8f5dc104bf0d276ee0c76080507ccdc5efeef7e5048df1a7b1449a499d0e40542366cf50d78cb6da7692761dc7",
+        "dest-filename": "@types-stack-utils-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.27.tgz#f47da488c8037e7f1b2dbf2714fbbacb61ec0ffc",
-        "sha512": "c0afe88b981c1e2ef654c4db39a43bd15703c52435b97f12dadba404af4046e197ad833ffaee28bbbdeba1ceedad70cd982c42a1eac4f33aee42a5ffc2e1eccc",
-        "dest-filename": "@types-webpack-4.41.27.tgz",
+        "url": "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756",
+        "sha512": "1790c8677e9854b13e3cdf99c30b38909a20ab8ee13605f7371e96c8327791ca65c7291edd723307cb8ae67fcba66d4706c6c6cddea79867a12fc70f7a43fe4e",
+        "dest-filename": "@types-trusted-types-2.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9",
-        "sha512": "dfb4521e1b7e833ce061ea1b6c6f8a5abc9e016f09df7361afaf5c8d3a9263299755910df4d6d1616a18951b4384728f553d45c8d2b06933c2d4dca7299a7344",
-        "dest-filename": "@types-yargs-parser-20.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d",
+        "sha512": "3c18c85316473ae8f4475e7fc6ec09623162f8a65d345ade86870286fe20e61bba685ae81ee7bc9b49413f43ce74ada72b36f0d1c815d66c2cf3e57f24070491",
+        "dest-filename": "@types-unist-2.0.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.13.tgz#34f7fec8b389d7f3c1fd08026a5763e072d3c6dc",
-        "sha512": "910e49353adb0efdd1a795f69ff894bb7ec82410d4da0b19e51fe0d7f28738e11ce4829f5058d74fa0c434f19dba1d3c23fa5a9b0b44ab8a2e97b814a8a4d00d",
-        "dest-filename": "@types-yargs-15.0.13.tgz",
+        "url": "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.5.tgz#2a1413aded46e67a1fe2386800e291123ed75eb1",
+        "sha512": "f548cc0872b918f81046835ba9d2c802f032d04227ba2a9b5b43c132d54fe81e41d8740996fa091ccf8aa1d3d93048ce6b956449cfb92c7ef1cbe714cd07661f",
+        "dest-filename": "@types-verror-1.10.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.4.tgz#d7ad5c311aaca3d7daebba169e1ecf35be97ceee",
-        "sha512": "0ffc2284ef56158ab0b26248d1ed2a4be534f70210b584520499575a34c51a3a2e12e382cb4054e0dfd92b9bad6f4d12e655bff4b3bbbcea6f18377c334e8dbd",
-        "dest-filename": "@types-yargs-17.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/@types/ws/-/ws-8.2.2.tgz#7c5be4decb19500ae6b3d563043cd407bf366c21",
+        "sha512": "34e9f978872058b3a8eaa5bc01cb8b67b1bc3f2717bb4c53c71912e90d7c55617180f5123b0574a418f66bfe2f88d655bb6e62ed1201ec6b6d7640085145ce3a",
+        "dest-filename": "@types-ws-8.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.20.0.tgz#9d8794bd99aad9153092ad13c96164e3082e9a92",
-        "sha512": "b30fb71cee5a7a162a9f9c35efbcf60fcd99425a870b070a48c6e8b9ea3ba04e0a53d4220b448081f4bf0f8cfdc57be94dcf01b78d5169af5f051f13dad221a1",
-        "dest-filename": "@typescript-eslint-eslint-plugin-4.20.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129",
+        "sha512": "eed1489a080d78d05532c9f4bcbae99f51f5b8fad405d9c044f4e96688ad637ed9add2511337fb235ead32b94ade17a7df8f60af535887c0a66506bb0931ba03",
+        "dest-filename": "@types-yargs-parser-20.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686",
-        "sha512": "0dec2a220b1c0f39807dde673867b8ce6e8197b3cab4c1b601dd0a1bc0946401e55df00a4c5f4e9793d7862321dfdc912f60a1447d5cbae50639c572cab85023",
-        "dest-filename": "@typescript-eslint-experimental-utils-3.10.1.tgz",
+        "url": "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06",
+        "sha512": "c842731e8c5fe92c901a10612181974034829098c1e87a210d286da3b9bcbda2a0f58a74627f3eef527d79a921d9b9cf83a05fb07f4f44c86245366777879719",
+        "dest-filename": "@types-yargs-15.0.14.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.20.0.tgz#a8ab2d7b61924f99042b7d77372996d5f41dc44b",
-        "sha512": "b103657faae32eadb20799442e5de0384eceba803fe8855725427e56cede9ab40cbdad780a43b0c90c03ec25be4e498e27843f6069a80cb99b7c5ae91a66ca9e",
-        "dest-filename": "@typescript-eslint-experimental-utils-4.20.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977",
+        "sha512": "4fc61cf70b7fe4b6c9c8268b8873d17896b4900a5c22027b067ef7e468c8b547e1d3c675a49beef1066a6fdb3e98cbca57a59441157b2b6478e986e33174d327",
+        "dest-filename": "@types-yargs-16.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.20.0.tgz#8dd403c8b4258b99194972d9799e201b8d083bdd",
-        "sha512": "9babc3b602fd10005d8ccb4a570e6bafa0dd78c087dce035bc56f4740cae6526b77b9cb0d584739701679bd92799af4bcfa6f618fbe83526bcbce5ebaac6a094",
-        "dest-filename": "@typescript-eslint-parser-4.20.0.tgz",
+        "url": "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.8.tgz#d23a3476fd3da8a0ea44b5494ca7fa677b9dad4c",
+        "sha512": "c03794c225267a6f45ceccb2b04c11ba468474335cc1b44ebd0f5019129a2c8eadf8896d3736e7e3f8b86ac981d746aebd91900b3490eadd0649ccc44e19545f",
+        "dest-filename": "@types-yargs-17.0.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.20.0.tgz#953ecbf3b00845ece7be66246608be9d126d05ca",
-        "sha512": "ff39ba591ea27250f91e11a973097f18e6034f3ad31e6bdff0b2cb9302aaa8f286ebe299b7f09f4a03c28b26ec866724eba3362f97d6485fcc28db82c2d29049",
-        "dest-filename": "@typescript-eslint-scope-manager-4.20.0.tgz",
+        "url": "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz#e5a86d7e1f9dc0b3df1e6d94feaf20dd838d066c",
+        "sha512": "5eff6d9059720f83101a92604e8eb0a83a86bc721199181a87fd928f3d4f5272536b08c7588c018af504f71d10b54d965628bd6da6206afa3f6c78eb64992a4f",
+        "dest-filename": "@typescript-eslint-eslint-plugin-5.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727",
-        "sha512": "fb7f850942486a113dab49438b55a5798ce30b026ce6122c6ee8088276c1f9d482614c65f0be8fc26b3238f15975eda17350e54e8ff19e43a08932d2c806c789",
-        "dest-filename": "@typescript-eslint-types-3.10.1.tgz",
+        "url": "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz#8c407c4dd5ffe522329df6e4c9c2b52206d5f7f1",
+        "sha512": "71bd4d8f2b2cd262cbf642d7812fde118e7749943db13e75f70a57de2f94e39ee5d945d10eea3cee180a7e045ace6bbdfed41bd31dacaf7634cab53e673d32fb",
+        "dest-filename": "@typescript-eslint-experimental-utils-5.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.20.0.tgz#c6cf5ef3c9b1c8f699a9bbdafb7a1da1ca781225",
-        "sha512": "71863ed4f2237a2d67938f4900f9c7d55127bbb39875645d261608e7088a3943212d31b5aacc79710c42513bb0582990a32ae269dcf7362f07666192a1f782fb",
-        "dest-filename": "@typescript-eslint-types-4.20.0.tgz",
+        "url": "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.9.1.tgz#b114011010a87e17b3265ca715e16c76a9834cef",
+        "sha512": "3cb60ed009b00fab3a9f465007992a3e07ef87bde9d3e56aa294102ee35f8bb2e6d04a5f2b20da95c869570904fbcd64e477a246b4d5ffdc3568d1f38c3ec2e2",
+        "dest-filename": "@typescript-eslint-parser-5.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz#fd0061cc38add4fad45136d654408569f365b853",
-        "sha512": "41b7173aeaba598be70775cfb19a48c33b41a2ab8460b5e1d8cb70554fa43bc8e06028afe06e71ad23ffd70838b64beb104f9eb1956ab883d7fddc4f95e3e4d7",
-        "dest-filename": "@typescript-eslint-typescript-estree-3.10.1.tgz",
+        "url": "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz#6c27be89f1a9409f284d95dfa08ee3400166fe69",
+        "sha512": "f01c2f5a4868dc1fd43adcd1c96d3b7df2573da2d250a1418e9abc6aab11beee87744bb3098e7bf9f7d3ed0a15e105c95d6494d7eee0df01380258089a643da5",
+        "dest-filename": "@typescript-eslint-scope-manager-5.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.20.0.tgz#8b3b08f85f18a8da5d88f65cb400f013e88ab7be",
-        "sha512": "2a7a69d2b78e77866cca8109756f22fec2b79ad678ecbb3b647bc3f1654004dc795e79fb2a17a73134467a0a32313c7a4e25e539580ccfdaf4a438174c41081c",
-        "dest-filename": "@typescript-eslint-typescript-estree-4.20.0.tgz",
+        "url": "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz#c6832ffe655b9b1fec642d36db1a262d721193de",
+        "sha512": "b514a97419cf46cb23954877e6b13dba0e47ad4bda07d9ed444cbb80f5d72b0988c7ad5334defe97960a822d6130ac68e4dbea6427d8840e45bf2b891ba5fabe",
+        "dest-filename": "@typescript-eslint-type-utils-5.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931",
-        "sha512": "f49802f3601a41e82579b8d9320611e708267d475473e122b46514316f2eda70dc91a7a29b35be56ca0b57a1688a63efda2777550cdf8f007110c573d3c6a679",
-        "dest-filename": "@typescript-eslint-visitor-keys-3.10.1.tgz",
+        "url": "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.9.1.tgz#1bef8f238a2fb32ebc6ff6d75020d9f47a1593c6",
+        "sha512": "4ac59e816b9d5a99190b0c1870aa03c2e023a195e7335cb611b11ead31e1a35f479a6f9b439e901b82f88ebb42bb46c8e524da453bd14d99a3a6b5a54f0ff935",
+        "dest-filename": "@typescript-eslint-types-5.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.20.0.tgz#1e84db034da13f208325e6bfc995c3b75f7dbd62",
-        "sha512": "357291337a0e5502fcc8d14334266e89e448c19e54b6334b62d98cc763da70400699b68462d1a054750757266f53fd2b619722cddad68c3a3e581b513d282af8",
-        "dest-filename": "@typescript-eslint-visitor-keys-4.20.0.tgz",
+        "url": "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz#d5b996f49476495070d2b8dd354861cf33c005d6",
+        "sha512": "80bd6c3fa03f286d07c2b6a155723d7d9c9e553c44615fffe8f99c3a7d6d0f4af0f158545987997ae587c308677b09ef10c7078e19c92ce06103dacae2f99bf0",
+        "dest-filename": "@typescript-eslint-typescript-estree-5.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964",
-        "sha512": "0bac16e4bf9bee88120d5ab299b924bee5bd92bb8dfff622b0c103d38c7378106a8c76b61589e6bce952e978faf315904605af23d708825b23168c07fd127210",
-        "dest-filename": "@webassemblyjs-ast-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz#f52206f38128dd4f675cf28070a41596eee985b7",
+        "sha512": "5e1dfba4dcfd7bdaf25b84d5770885ce6af8865a2dcbc7058fc19358c5e1dd9f2cc06c3241678270d805d219bab74f6265de9e8999887f8cc779d4153fa4d5b6",
+        "dest-filename": "@typescript-eslint-visitor-keys-5.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4",
-        "sha512": "4c6e6a705b12f10078838321af12b94ea7dd35eec4cbfed82ffc4dfb7eab46397f065184fcd701bc972ab118023fa67dda6444fbb379d294488bc4a62946dc40",
-        "dest-filename": "@webassemblyjs-floating-point-hex-parser-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7",
+        "sha512": "ba4061d78a852e3c5340d4d7a1c77292c37941d336f12d42c47b76addb241722fec4557b56b7a6b812d56e609e3e3f9445a957044371ffd2e6ee59e18a1b424b",
+        "dest-filename": "@webassemblyjs-ast-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2",
-        "sha512": "35c30b8e814c5e9b004991712798761d945c1210e4be73453802a778fe516ca47369624ddfa342e23a901cac12b488465eee66516954524ef281db6b3bc95b9b",
-        "dest-filename": "@webassemblyjs-helper-api-error-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f",
+        "sha512": "88645fc9ce41abe36736e5fc6f987006b463cdfd2872b24f23a1961687411739859f2beb43cdd21ca8668a5094ffc26febb8b818964132113396dc7370d6a0b5",
+        "dest-filename": "@webassemblyjs-floating-point-hex-parser-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz#a1442d269c5feb23fcbc9ef759dac3547f29de00",
-        "sha512": "a99a25e37a2a86aeb204fc7b60cde6f41bfb58c57d11ebe3ea4322e889ca3ae671870faaf613a4beae5efcfa4a4a22dfc9eb696819e88126cd09f070c81d3408",
-        "dest-filename": "@webassemblyjs-helper-buffer-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16",
+        "sha512": "465852f020425df45447f730a36868f5b9217925c6d3e370a285dc7373c020b00b7f640b745ca3eca1ac2916d573de61667867111a27e245bf0f7499a69e9372",
+        "dest-filename": "@webassemblyjs-helper-api-error-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz#647f8892cd2043a82ac0c8c5e75c36f1d9159f27",
-        "sha512": "1110987490640fd56ee2fb635187bc2d9aee5ae3484e862afcc136da280bfb6be3d9d43638eba3219af730416f7c46aa2a856aa6c14a006b117414818eb22f64",
-        "dest-filename": "@webassemblyjs-helper-code-frame-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5",
+        "sha512": "8308a417ae5a0cd79e5daf09c576b604093e4448d2ca1acd0bd670753d1ff2373875041e0d0ec6e26d1fd9008b3c988c4d33bac1f0e64668ffa56d0fb14bc870",
+        "dest-filename": "@webassemblyjs-helper-buffer-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz#c05256b71244214671f4b08ec108ad63b70eddb8",
-        "sha512": "38f468c2119bb2109be4fc49f0ba1ca5d5fd2a5d2e0785ec02397a8c7fdd58a964fe6cec00dbe1c1b8942ec6a2a93e466464fdaa29d3202763e8f2ee33982c97",
-        "dest-filename": "@webassemblyjs-helper-fsm-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae",
+        "sha512": "bc391bc6207ccdf9cf74d2bd45a8dc7b2e42d30f9026e804825374a1ffa498ef25ee50dbefb02794a61017b69aad9b82aeffa5d14bea2feebc8120ebde4f4b3d",
+        "dest-filename": "@webassemblyjs-helper-numbers-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz#25d8884b76839871a08a6c6f806c3979ef712f07",
-        "sha512": "309096f22182d3cb4c9367a7724d5a3d6f811390b0f3fee987f546671c32bc66c9c2392d2a40caeefcbb80098c0f1f3c0fb9a10d308d2805b9b440fe819d16f2",
-        "dest-filename": "@webassemblyjs-helper-module-context-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1",
+        "sha512": "3efa68386889c17793ad27ffa9fb9d261c25bc34311607a56ccaadab9d965a25c2e97820d484447678263cdddbb384683bcdcf9cbfe716bc6e7178f5f815fad9",
+        "dest-filename": "@webassemblyjs-helper-wasm-bytecode-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790",
-        "sha512": "47b152b48cf235c77bc4ac42647e6513406acbe8464f04b72c98eebf5655c5df4eede1c279d49dac877f84c39ddb423ebfcc035c49fe6e37ca0cbcd37a9a1a53",
-        "dest-filename": "@webassemblyjs-helper-wasm-bytecode-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#21ee065a7b635f319e738f0dd73bfbda281c097a",
+        "sha512": "d743fd368dbdad85f58fb1771153d7dc9bc63d03da7be0289ae4933e217d78141e0a11c8ea2aa3308c11f4998e257c299e7fe85460e4ec8e4896c92e33053fa6",
+        "dest-filename": "@webassemblyjs-helper-wasm-section-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz#5a4138d5a6292ba18b04c5ae49717e4167965346",
-        "sha512": "5e7301f25dde938b6faca51492ef8855a5cd1f3d98b09c8e3a6cfe30c919be1f21d6e489a527a7eaf627c3722843b5b012e0212fc11f8e6b356568ea8766a0bf",
-        "dest-filename": "@webassemblyjs-helper-wasm-section-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614",
+        "sha512": "849f3b4083ed00c29b16ae821939196098af1306436d052061ddea29269d4cd3a1558ee9fa07cfe92af494b4554da1b5263163fabdd8721a2a458c4d1f733419",
+        "dest-filename": "@webassemblyjs-ieee754-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4",
-        "sha512": "75c5fc26e614fe0bf29b320773d0e0c53cd45132dec56c2df2e09358fde8b72b39f7a8a8d0be5a5b4d866f5463629c76fb426eb35878645aa395aeee9859e24e",
-        "dest-filename": "@webassemblyjs-ieee754-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#ce814b45574e93d76bae1fb2644ab9cdd9527aa5",
+        "sha512": "049d8fd21359d2ef938756195c9a735ba9a2c2a41419c2074f51bfb1fef680b543f4367901d613a8f35b1d987a2b53395662af157c064966400f3faa056c5e47",
+        "dest-filename": "@webassemblyjs-leb128-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.9.0.tgz#f19ca0b76a6dc55623a09cffa769e838fa1e1c95",
-        "sha512": "10d573339570575a23b3d8da9babcfcacf7b07f4bae5842dbff69a9ea9d4ec3f1a4a81c55fc1b284683408c7f228d20706e0158f2ded97377940c30835aef0a7",
-        "dest-filename": "@webassemblyjs-leb128-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff",
+        "sha512": "f64a9cc4011d3218b04241e990d8a8ad9ceaa46ae8750436206ac71f10b2f8ece7834a1fc8c034953aa22e456cd6ecd345e8d7fbf3b410e4fb2b1a953ee5e8b1",
+        "dest-filename": "@webassemblyjs-utf8-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab",
-        "sha512": "1996d0956b68a414cfd2eedc1eb131fbbdf264aad0a01329c2418422a95a7258e15c291533590c4207bf31ff9cb0c2408c4752c213b22c04b4028477006e4ff3",
-        "dest-filename": "@webassemblyjs-utf8-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#ad206ebf4bf95a058ce9880a8c092c5dec8193d6",
+        "sha512": "83e46cba9502d5a4c77d1f020e09ec551559149a9d9051e9b0731f26e590cd6537b6f9cb0b4ed4a872027cffb85f22f6b67af56a6be5d52769d3a4e760299590",
+        "dest-filename": "@webassemblyjs-wasm-edit-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz#3fe6d79d3f0f922183aa86002c42dd256cfee9cf",
-        "sha512": "1601f3066f34bb0cf933c58a9cc4e7ea3fec55baa294f7505d35ab6928c1c055d26068aba6449613647d42fcfdb4d893290be82882e90ae4e304acce226d27c7",
-        "dest-filename": "@webassemblyjs-wasm-edit-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76",
+        "sha512": "17b42a297c30365326b2e963ebe3bbaf89a6b4094259f3bfd077603b14a49597d0703bb44e92e20f5991b7fcc5db9064e7d1488c4b86008ca7e5e8b8c8c7cb84",
+        "dest-filename": "@webassemblyjs-wasm-gen-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c",
-        "sha512": "70f137a38e18cce387be5b1be3e13da92aa373d41ff4d6b538efc11c5cb8388f755c3135e0c8c537895331ecf368859d3ea1e7b13a1d18634ffa245261f1a48c",
-        "dest-filename": "@webassemblyjs-wasm-gen-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2",
+        "sha512": "56a9e436a9d9954e4407ae29a7597b85d9b7866430ed582a6b4285fca08d3bdb08a48e8593a6eb0c4897fa208e62bbccb81583c2cd0d9133b16046fce574071f",
+        "dest-filename": "@webassemblyjs-wasm-opt-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61",
-        "sha512": "4248e09ba027866f8e31b20bd22a243bb99e6a3933403ef58a87a59df3c48faaf878e16eaa6e180b75413ea5e3172c8dc28c336cc0fe862ce6a6b3ff170925d8",
-        "dest-filename": "@webassemblyjs-wasm-opt-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#86ca734534f417e9bd3c67c7a1c75d8be41fb199",
+        "sha512": "aeb06e8f0f9d26edf681807bfcbba9e9485d90fc7d4bd4a7a1b6734552fb55c047f41b7d6c204b12e5ff61738eb41b0e678350ad1ca42a17df4561ef8a042f38",
+        "dest-filename": "@webassemblyjs-wasm-parser-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz#9d48e44826df4a6598294aa6c87469d642fff65e",
-        "sha512": "f7ec24328c11d8099d496433b0f123154ee78e1f074cee4ca8ef2f8f0107b8cf803078a836a48138d45daf435043775542bce9d2cf254dc62acd475bed88042c",
-        "dest-filename": "@webassemblyjs-wasm-parser-1.9.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz#3031115d79ac5bd261556cecc3fa90a3ef451914",
-        "sha512": "aaca9200fdd04372f2663342ff48c127f4e84b17d827c918cae886bed9fff0c2bcf55acd11fc23ec13d0cc95478b48c64d12b6746749e4f46a86d8f3a30c3e6f",
-        "dest-filename": "@webassemblyjs-wast-parser-1.9.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz#4935d54c85fef637b00ce9f52377451d00d47899",
-        "sha512": "d89d2713de6b1d71f2436e1c5a330a275b6a07f76cf33fdcc9e399c4985c6fead6f924004958eece751299dcf91a95494f353c264858badd03dec8850c3eb0b0",
-        "dest-filename": "@webassemblyjs-wast-printer-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0",
+        "sha512": "2106e851633878acd65be37f8e28f6b116ad28c87df5011e968dc46f6ab4a9792f3d1212023f10c6d9b0e62b70a8af934e406e508138e40c583d3a2a3ed2f982",
+        "dest-filename": "@webassemblyjs-wast-printer-1.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2029,9 +2036,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b",
-        "sha512": "2b43ed9bfe3b38a7d0469350d89fe820dff741888ae85c16f9e25b20b86c7718765932dd97edf4a3c6867536e6e496df7e9145020fe0fb38b513e8ef2616b99e",
-        "dest-filename": "acorn-jsx-5.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9",
+        "sha512": "9bb559de3c33e1e2ba03856db7c130d7f98d6cfdb8bb41617727c0edf4af9c947a2cc75f3989e6b88aeb24082b61f609d7417fa2d6874edaedaed98774c37313",
+        "dest-filename": "acorn-import-assertions-1.8.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937",
+        "sha512": "aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
+        "dest-filename": "acorn-jsx-5.3.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8",
+        "sha512": "f26b7e7ec943b9f2d89ed2283c06883147bf96b6eb7a1222c26477b7693d2e58c8ce88a010f176ede2e4da1cbccd21b3991fe882bef36d128834ca35bb4ca1e4",
+        "dest-filename": "acorn-node-1.8.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2071,16 +2092,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.2.tgz#d4632bfc63fd93d0f15fd05ea0e984ffd3f5a8c3",
-        "sha512": "f9ba40f4c26c1dd6786e07c3729934a3343286155cb7baf33a63b4b35208af40061a0281963b2cf27db3a75d6b44fdb089de5519e874e0281e2b381ab79ff6e4",
-        "dest-filename": "acorn-walk-8.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6",
-        "sha512": "5ed188857c05f1833c6c9846c46e645e08e412e3462d392862a544f8a311f9ab29af828662629883bc947b72a087243dca178dc0b9e39b387fefe81f0c198709",
-        "dest-filename": "acorn-6.4.2.tgz",
+        "url": "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1",
+        "sha512": "93e8b21c4b8f812c3a49bb83a4640cfb4e874146b4e03677a3e17a092cd732fbc8e4a32f9da12a5def9855ee79e51f679fa18fb78d387e8b38c1c829c35d920c",
+        "dest-filename": "acorn-walk-8.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2092,9 +2106,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/acorn/-/acorn-8.1.0.tgz#52311fd7037ae119cbb134309e901aa46295b3fe",
-        "sha512": "2d6085fd69f49df1ce989f6bcd00291a7c67be07d13b31a2952f3ddfaaea37f95f718918f4c619cdd32a37ed8d2784a54dcfa6e478926be90d7c3b48eb877050",
-        "dest-filename": "acorn-8.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf",
+        "sha512": "57f2c6af500fcbe3d723029e6c45ab9193f0a1ea05fb0d6388e0549aec6e89421a387b686fc41cf414eb628ed5b88e5f47cb6ab32f9bb80d96168a11e6896abd",
+        "dest-filename": "acorn-8.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2106,9 +2120,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz#5ae12fb5b7b1c585e80bbb5a63ec163a1a45e61e",
-        "sha512": "601ac6c93dbfb9543f73a46bfade992579e2634dd8b4718c25061a977ebc6eead11982aa871f6a1935aa701539b350b0618f44feb8badd16321b521a70c66dab",
-        "dest-filename": "adjust-sourcemap-loader-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz#fc4a0fd080f7d10471f30a7320f25560ade28c99",
+        "sha512": "397c0de5bf690945cd407269c300f6a8fe346f21264a0ce3f01e32752374b8c3585a216627ac7a2b052594c99f93c470bbf1c90c547b53cb9bb160683745e9d0",
+        "dest-filename": "adjust-sourcemap-loader-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77",
+        "sha512": "45937035c945efe312ffc6c383bd1a9a0df6772799199c620ee42667128b025423af78c6c8bc7ee0a924e7c50eec3d90760148402a2fb92b991129dee911ba5d",
+        "dest-filename": "agent-base-6.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2120,9 +2141,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d",
-        "sha512": "0c245f3bfe2743ef3da7f44ae378bc133778d44a9d18853895dee7185f0e435e2873fc1ee6b127b4b0946bbfa3ae7de79fcdc1a2c7f0640d306f8a689f6a3c89",
-        "dest-filename": "ajv-errors-1.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520",
+        "sha512": "5b1d0ac79da1c44ec2d7c8643048206251227ea599b58691828b89a2bf9631d3e743210ad77be0116c9536ea7b4a879ea0b32caf891fe61e9d396d75235e4c50",
+        "dest-filename": "ajv-formats-2.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2134,6 +2155,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16",
+        "sha512": "6024bf24d140532af9bc0ba19350d69b5081c511d6f4b6c9da8cd679e9ab22aa5bb2a2a31d5c583f28b9182d2b8d9213e49c49def8ab5534bcc24e22fd9fa4af",
+        "dest-filename": "ajv-keywords-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4",
         "sha512": "8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2",
         "dest-filename": "ajv-6.12.6.tgz",
@@ -2141,9 +2169,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ajv/-/ajv-8.0.3.tgz#81f1b07003b329f000b7912e59a24f52392867b6",
-        "sha512": "0dfe8d022beef4aa59c3eabcc928a30202efaf59940398a1911bc22c2c69758476d5a9e7e7222e37e3e91719b07928fb8b7ca3274c792cde4a56cd11473b2401",
-        "dest-filename": "ajv-8.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb",
+        "sha512": "c7d56e5fe47f8dc163d431e8fdf0a9f7d7ac8060d688710dacac5a08436e0b1a68302980b7f08e086543c00ee495e1291332630e7be1df21a83ae2eed03b6597",
+        "dest-filename": "ajv-8.8.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2155,16 +2183,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb",
-        "sha512": "6690a554aa973774460662a26dd7d6cea098e259e312ea0dcd4e53d28105a5f77fcf9a891d56abba4ae2743e23b8b3b6157322c14431afd5aa42d6986bc5d163",
-        "dest-filename": "ansi-align-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf",
-        "sha512": "84751719a81e7e3376891ac80fadf172422fa2d3973a88e140a5883d467898d519f672d95beec530da04d653a412135662cc7fef2b0622e2580a230003d167ac",
-        "dest-filename": "ansi-colors-3.2.4.tgz",
+        "url": "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.1.tgz#0cdf12e111ace773a86e9a1fad1225c43cb19a59",
+        "sha512": "20e7f0c0117989ccce8e9fd6798e18c728ea005310a19b9f750583775f52104c5b54b357aafa73489fcced96b8fec08f990d3e191aaea00edb19c20d7317b0eb",
+        "dest-filename": "ansi-align-3.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2183,9 +2204,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e",
-        "sha1": "813584021962a9e9e6fd039f940d12f56ca7859e",
-        "dest-filename": "ansi-html-0.0.7.tgz",
+        "url": "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41",
+        "sha512": "d403c7032af7f8f09a9b0370ddb5c23e9e0714b38d66dff2207d2c669d3fe3af4a58d4c4cbea8de634371955fa0cc675517022df8c95c2d4de686fc7a41baecf",
+        "dest-filename": "ansi-html-community-0.0.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2197,23 +2218,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998",
-        "sha1": "ed0317c322064f79466c02966bddb605ab37d998",
-        "dest-filename": "ansi-regex-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304",
+        "sha512": "aae2505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+        "dest-filename": "ansi-regex-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997",
-        "sha512": "d5aa5e3df5ccd54392ab0d28f48885028bd5cfd3394b50e0fb84eb0f07cc7b043aa7fae632e79beed5998d0d6bc782e8cb502b060828a86a5faaa748e2ba2776",
-        "dest-filename": "ansi-regex-4.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75",
-        "sha512": "6d8e9f8f9e8e510d215352a314d0d0b8915ecea29dac0c857487af0038aaad61f04a56e604d307a796a4d9fe343e6f094c5c8cda6ab1906ea78241ced757ff96",
-        "dest-filename": "ansi-regex-5.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a",
+        "sha512": "9f933ce797ca6f64ac7cc222145a15ac0047242f10b47c15c7e98758fdd0704a811d889e9e3e5d1d28236f1b42d161195d8b78c1c0faceb4049433e116e6607c",
+        "dest-filename": "ansi-regex-6.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2232,16 +2246,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb",
-        "sha512": "e6d78eb105800571c70453fdcb7b244b93f777f59f597a6fdc5529cbe2e8accacd61a4fda48e282cc417ee3cd0d8a9253691a9587cdd0974c34f66375c695907",
-        "dest-filename": "anymatch-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b",
+        "sha512": "0b1c29b7649f4f34ed5dc7ce97318479ef0ef9cf8c994806acd8817179ee5b1b852477ba6b91f3eeac21c1ee4e81a498234209be42ea597d40486f9c24e90488",
+        "dest-filename": "ansi-styles-5.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142",
-        "sha512": "98cf39db6a6c442ab357ee8b868997e70829db961589b8e1f168f6dc8e513e43e9a525528f2283d80da604999619af8a37b7f60fa2cd87d8e40427b22e4b738e",
-        "dest-filename": "anymatch-3.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716",
+        "sha512": "3f8dde3df38022ea6482e1d4c9cadce2a27d933f198ae3948a36844f05fb4c7b7463f18d2bbbf469af2b63cd7ac568d9eeb25d0395dd31ca5515328cabe46f5a",
+        "dest-filename": "anymatch-3.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2253,9 +2267,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.13.1.tgz#9beee0dd3df32fcce303b933d187bf986efe3381",
-        "sha512": "4ec51eee009d1f57274a49d472ac15440031b05c6cc5c53f049be7291f004b38da66d78f5bb314f8011a0d50d4511c9c818c50f577b29868e6b90192df68dc6f",
-        "dest-filename": "app-builder-lib-22.13.1.tgz",
+        "url": "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.14.5.tgz#a61a50b132b858e98fdc70b6b88994ae99b4f96d",
+        "sha512": "93757028fe24a6c9d4697a14926d6ce336921cf1c83059cde243cc53dc9768a984d4b7c71ea05a11a8796d7793017e55fc10b8d7015d83c085e6f3a3be0cbc46",
+        "dest-filename": "app-builder-lib-22.14.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2270,6 +2284,20 @@
         "url": "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a",
         "sha512": "63d27a6635eda1887c4675d508c394fedb439a4d5a063ba7abdbced2d6b9c7ce560d08907d417db083c121375b8a2215701a34dc78b78ccc62801b6c75d95747",
         "dest-filename": "aproba-1.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146",
+        "sha512": "9f1c32e344ee322506a8cc911e0092599f45338540a113f8c546124efe48991a20fa1f722123db547ec7f1f012088cd89fdc2512fe33bc52fbb8a0cc085426de",
+        "dest-filename": "are-we-there-yet-1.1.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/arg/-/arg-5.0.1.tgz#eb0c9a8f77786cad2af8ff2b862899842d7b6adb",
+        "sha512": "7b48436bd1f667d030164936a83970868318138793a0a6ab7219101e8bcd74b4c260c1d91de46323bd5cace87e762a382babb521cc2e6d0aa8efd19ae02c8040",
+        "dest-filename": "arg-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2295,34 +2323,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745",
-        "sha1": "d9e76b11733e08569c0847ae7b39b2860b30b745",
-        "dest-filename": "arity-n-1.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520",
-        "sha1": "d6461074febfec71e7e15235761a329a5dc7c520",
-        "dest-filename": "arr-diff-4.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1",
-        "sha512": "2f784a57947fa79a3cd51eced362069f0a439a4a7a13df365e1b5bbb049edcee2a3ad30c32da1d89c0120350a7cb653e6825dc3699a5fa6e1d3ecbec2778dab6",
-        "dest-filename": "arr-flatten-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4",
-        "sha1": "e39b09aea9def866a8f206e288af63919bae39c4",
-        "dest-filename": "arr-union-3.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2",
         "sha1": "9a5f699051b1e7073328f2a008968b64ea2955d2",
         "dest-filename": "array-flatten-1.1.1.tgz",
@@ -2337,9 +2337,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.3.tgz#c7f619b382ad2afaf5326cddfdc0afc61af7690a",
-        "sha512": "81c7a6d4a94153b73dac1f91abcff73cf2ac2b6923a9e1016b76c3e64910a389d894e1d0089a88245a815c311fc1a46e6134f813e17103dc5ecfb19ffdedd0ec",
-        "dest-filename": "array-includes-3.1.3.tgz",
+        "url": "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.4.tgz#f5b493162c760f3539631f005ba2bb46acb45ba9",
+        "sha512": "653352424996ba611b8873b6185e06996c58553890c89cb65ce4dad79b1d412aef2a7ee5fb5f347a040caa5acc394302c8b303ee99b241ee26303513e817a1af",
+        "dest-filename": "array-includes-3.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2372,23 +2372,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
-        "sha1": "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
-        "dest-filename": "array-unique-0.3.2.tgz",
+        "url": "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz#07e0975d84bbc7c48cd1879d609e682598d33e13",
+        "sha512": "29a614f92fa7755ab25278a09c77ed930739f28dee554d63cdccc82c9d6d37661a219a4520a0623ffc7f8fdec4e4c54fb1a0a5a0f6ea58b07ff2a09356f4f6aa",
+        "dest-filename": "array.prototype.flat-1.2.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz#6ef638b43312bd401b4c6199fdec7e2dc9e9a123",
-        "sha512": "e38ef45e2dc600f02366a15c9635f6c73724bf5a9e28f8b3a0d9224b4f8ee08a0f47664da5c8c4d299217628650e8b8afb1e9039ab2ddba07843f3bd0c99f04a",
-        "dest-filename": "array.prototype.flat-1.2.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz#94cfd47cc1556ec0747d97f7c7738c58122004c9",
-        "sha512": "afd674cd8a31a87cfad2fbd06d611d5c812d0b01c5d32c5a59f9e8f6acd778d1ef7f2977059ab28261b36fce1db2e6f26972c7e21bac17e34580c49da59864d9",
-        "dest-filename": "array.prototype.flatmap-1.2.4.tgz",
+        "url": "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz#908dc82d8a406930fdf38598d51e7411d18d4446",
+        "sha512": "d3cbbaad5ca2d4b8fba2a59b4bd9d4c658844ebb4844e4f85c64c0e03fcb586b5e9fa137a1c9bb732f5222b98d1ce2f95d56d5b9c914a775fa5f283cff3a6f1c",
+        "dest-filename": "array.prototype.flatmap-1.2.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2400,13 +2393,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa",
-        "sha512": "dddb84c2d8bcf34c6a8b878030df00c91e1ad01c93f74ce861d2e57af7ebbd4e37bdbd186706557f13a0c56acb5d75e9cae80bd2135973d1ba0620790779d4ba",
-        "dest-filename": "arrify-2.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46",
         "sha1": "e50347611d7e690943208bbdafebcbc2fb866d46",
         "dest-filename": "asap-2.0.6.tgz",
@@ -2414,23 +2400,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/asar/-/asar-3.0.3.tgz#1fef03c2d6d2de0cbad138788e4f7ae03b129c7b",
-        "sha512": "93bcddf8aa11fa7f2997bd4fbe0125728287ad5362497b70ee874a6f23699a029eec419117d3e7bb7b8b3ae903dfb12f6af2b0545c4e529a974c8642e41e4f9b",
-        "dest-filename": "asar-3.0.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07",
-        "sha512": "f88fffe1c60f71c57c2dd9812e25fc098bdff52a77bd0b2baaed9035745cadb896bdcc7f51d9458aa509273c5143182c666be15e19f871229e4a6a058d576ea4",
-        "dest-filename": "asn1.js-5.4.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136",
-        "sha512": "8f1c334292d08d29965e0c1a09913d373fa09401b4d721754275a06e11b01c8e40e85448118e8856ab478487a91ea23bfe4c84c9011a8010b998110594862f76",
-        "dest-filename": "asn1-0.2.4.tgz",
+        "url": "https://registry.yarnpkg.com/asar/-/asar-3.1.0.tgz#70b0509449fe3daccc63beb4d3c7d2e24d3c6473",
+        "sha512": "bf2c4fc4fe5aadc02a37817f79b1ddfc78709c0899b7086096f76673b051d9fd32c1b54d4cea527b284b0db197b44ff2e7c86fd680bbe5368d217bad9ec399b1",
+        "dest-filename": "asar-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2438,20 +2410,6 @@
         "url": "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525",
         "sha1": "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525",
         "dest-filename": "assert-plus-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb",
-        "sha512": "103b206b0cf0a2e9f609990282dc496efdfddafe276e4f570c3d3acc8fa4418a0133fdd10562e51322404433a6840028b018d600212428be92fa5219b5c02e6c",
-        "dest-filename": "assert-1.5.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
-        "sha1": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
-        "dest-filename": "assign-symbols-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2470,23 +2428,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
-        "sha512": "cff5a143914fc922ddbd1101c88daf6624d6c029c5d26a0c27584af584300d31ca87a23bfee49c90c7ada1119be540593c2d73d23970fa7fd70a08de1fbcb501",
-        "dest-filename": "async-each-1.0.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3",
         "sha512": "356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
         "dest-filename": "async-exit-hook-2.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd",
-        "sha512": "72c3a558601c44525a23a9be17658a76730aaf81e1761155064d07fd06c914c0abfae3b6930a21c1740fc70ffd382c69d39af9821541152ca2a22c71de07e435",
-        "dest-filename": "async-limiter-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2519,44 +2463,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9",
-        "sha512": "5a6eae92868e1898bfef7a7f725d86bcb8d323924cd64fced788ac0fbdd830bf12b6b1ffeff9511609a0f272026600f76d966f8f0086c6d30e0f7c16340bbc72",
-        "dest-filename": "atob-2.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.2.tgz#25e1df09a31a9fba5c40b578936b90d35c9d4d3b",
+        "sha512": "f5f38fa472ae0d6d70ff410a7d19959f14c3b7cd7ae8c0272c8de6819d490a784db585b1709e9477908efc054e662fc0bc56bc0d8f514f2de1dfeb45065aeb75",
+        "dest-filename": "autoprefixer-10.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f",
-        "sha512": "5ebbcfe15547751042757d52dd65d50fcf91c86f6a79bd43e529f50de2e21b6c5f4a9cde965939939e316d41112773390e0810c5eb37f5418e4cff0216b1066e",
-        "dest-filename": "autoprefixer-9.8.6.tgz",
+        "url": "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5",
+        "sha512": "58a4d6d7ec40ce1312e5d26cc569258a2c653bf3ea0b856198ef53e23b8d61c69383d8f35a226ca2eea6e69c566067e28166f0cc959e158eb3e3b6bee277915c",
+        "dest-filename": "axe-core-4.3.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8",
-        "sha1": "b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8",
-        "dest-filename": "aws-sign2-0.7.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59",
-        "sha512": "c61d51977e21e858b50c2d9658a7f151356a46c367afa2ec2b3dbe85fc03c502569abc7cf9cef295aa8131c1df975535af676c89f3af297dcb42e2cd67e5d2bc",
-        "dest-filename": "aws4-1.11.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966",
-        "sha512": "bf03e91f8023e35db6116dfc9b13bf7f18462adc164cc2c32097d9d477b411d6ed8dc7e76bf477601ebbc9585ecd4333a9cdc9af7f888b9d0a467b6510d2f8c5",
-        "dest-filename": "axe-core-4.1.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8",
-        "sha512": "74a422447c460fd3cf44850d216bd984f4cfa65d6b7ff3b14d82aca8a5038c1c18ca54ef57b4a348725bf6b6ad7f2ccceb009d2c23982f3b3bdeaa60e5ce2218",
-        "dest-filename": "axios-0.21.1.tgz",
+        "url": "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575",
+        "sha512": "bade6f7b0922bbc8e318176aa4ce385f18ee0a3abd2c029e1d59a855f1d5cf2f1e1e0c71abc49b01540da2f0c0f26562d3990fd046bf9ff5337121dc4c941f36",
+        "dest-filename": "axios-0.21.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2568,30 +2491,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232",
-        "sha512": "89f59a4c743471efb8e3c098a29f0076b42206c1ab9c2f9b3207f2285762e84b0f2d30161be41fc8378ce8e1fe1665a72af12ae4d9c130bbe50543ca419a034a",
-        "dest-filename": "babel-eslint-10.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.6.tgz#4d024e69e241cdf4f396e453a07100f44f7ce314",
+        "sha512": "a992f4253d074b52fe94eb87fb10b60d50124779ee9d98bfa331a1a606ae24782623b7fcaee7717fa8548c41f29a9750fc9eb809d2a63e481f27e03753a402ae",
+        "dest-filename": "babel-jest-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz#0a2aedf81417ed391b85e18b4614e693a0351a21",
-        "sha512": "a965b38b84e575da2103dd5b17082deb33bf2745fe8a8ed0a75f38170d26d8961149366725b151f3ed3b2a6cee74709980e88a442ae3872970bfd5ddf207e155",
-        "dest-filename": "babel-extract-comments-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056",
-        "sha512": "a65e10f86015387c2f8eb724ea32a3be61a19cede31d7ff1b81f5ddbb7fe10967fea4fba9ccb8f8e8aeb629eecfbe6ca29d00dc331250569cb59a39bbd39da64",
-        "dest-filename": "babel-jest-26.6.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3",
-        "sha512": "eeaee70b5b583abaaf52b3772d02b81b04a4fd3428ad948e94ef42f916436693838323786650aa139abd703b3258e96237e694f41e095f4d712bd7895e8c092f",
-        "dest-filename": "babel-loader-8.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.3.tgz#8986b40f1a64cacfcb4b8429320085ef68b1342d",
+        "sha512": "9f865eb5af0d0b7400b2eca28b3bb41a4991710e9c96457d58552751fd625cffff21e48a6d68e87d6dd41f2655c25381e32d37f5840a79f6b0c939fae19c1bbb",
+        "dest-filename": "babel-loader-8.2.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2603,65 +2512,51 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765",
-        "sha512": "005e79ad95e97bbb6b984ca56da1351afe78c27eabc14d376a9b6f46854818ff18ca4a12c6a7552d5d537f07e504213f42d1e6aad3fc49695310da9b2bc18249",
-        "dest-filename": "babel-plugin-istanbul-6.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73",
+        "sha512": "635210a24f7cdb5702f689c2c79a2d8057d19bb2e6f88fb0c313b1ef7f0cfd62cf67d438da6e081b95b414d5fc58b2f6818319a37264b97207d833a958cfaac0",
+        "dest-filename": "babel-plugin-istanbul-6.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz#8185bd030348d254c6d7dd974355e6a28b21e62d",
-        "sha512": "3cef6dd3af7b94d4e67041c7ebd99db5888e22490e963f5fc92a9f3b72b578271d2127af2c0134c58e7d54b2d48f44a888f8935ff254d82605a482f27546b92f",
-        "dest-filename": "babel-plugin-jest-hoist-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.4.0.tgz#d7831fc0f93573788d80dee7e682482da4c730d6",
+        "sha512": "25cbbba92e0e5f9913581738e47cfb04c9a05ee26a46785ab6aa54867cc60b73816293a67f6b6fea314dc19a7033bc14ecc52ebf6afd20f4bf66560eb9bbab57",
+        "dest-filename": "babel-plugin-jest-hoist-27.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138",
-        "sha512": "4843f9909a5f198a982a906b8f95d4dda870e69e46387274539b2c39243f58155dc240f60f395c7bde5ec504ecde339558f3ca2c1376ae51169022bb75298bbe",
-        "dest-filename": "babel-plugin-macros-2.8.0.tgz",
+        "url": "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1",
+        "sha512": "0a0ed3146a48af4d6f39034e0d738e686cf6369094e6097cc75a8915b6fa85b67147b5eb704dafb5b02c4c06c9effc7026d52e244c3c2bc66bfc01342c795eb2",
+        "dest-filename": "babel-plugin-macros-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz#156cd55d3f1228a5765774340937afc8398067dd",
-        "sha512": "b2abb249191ffba2469ef8e852d0c48d2444244062ae75e2f4da8feab8d262cca5c50c6a053cfea6499fdfde62f44db3b2f99851a238d011e8e92a9951dc9d97",
-        "dest-filename": "babel-plugin-named-asset-import-0.3.7.tgz",
+        "url": "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz#6b7fa43c59229685368683c28bc9734f24524cc2",
+        "sha512": "59788073efaaa3b5dc2756674d81ad2f19810956dd7409a5dc2117816681ccdccb368c6d43c02218414330e868b7d5e34c241bbcfe44efb163f4693ddb87f4d1",
+        "dest-filename": "babel-plugin-named-asset-import-0.3.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz#a2c5c245f56c0cac3dbddbf0726a46b24f0f81d1",
-        "sha512": "0cef79c03e20d00f0a45a1ca8b40f9d4d7465f3be9a952e72eee414ef0e5a6a504a5399e12dca9802d71a9eb0e45a5a6894390235e141ca97335df626761b764",
-        "dest-filename": "babel-plugin-polyfill-corejs2-0.1.10.tgz",
+        "url": "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz#407082d0d355ba565af24126fb6cb8e9115251fd",
+        "sha512": "c0c0e8049eae1b8bb83cd161ef64f2eaddc481f03dd69b82b80c0a21acdb425722f8435bfd453d037c46e65bad8d42225c2227d426392f5e6bf4b8a6889cab48",
+        "dest-filename": "babel-plugin-polyfill-corejs2-0.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz#80449d9d6f2274912e05d9e182b54816904befd0",
-        "sha512": "bbe81b4bd6db3e165611ecb2d6847f61a692a6877f2834f4edaad91dbf34693a65f07e5906afae3759cdf7fc6d5fb8d0c9f2dd3dfa2a23846e7bf31049626abb",
-        "dest-filename": "babel-plugin-polyfill-corejs3-0.1.7.tgz",
+        "url": "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.0.tgz#f81371be3fe499d39e074e272a1ef86533f3d268",
+        "sha512": "1dcae09e691ffb82538fbdc66caddb0619553e22cbe3ba305009e82487faf476a4977abe29fa1d6c35e265618c33b8aa0994f1086dd9d9545f3cd6044b8ad7a9",
+        "dest-filename": "babel-plugin-polyfill-corejs3-0.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz#0fe06a026fe0faa628ccc8ba3302da0a6ce02f3f",
-        "sha512": "394ad81bd88a3cacfc371b305db440752c05d0685174810c4e5a10013262e1b0ee16aad7697702513fd518daebf2905c8cc87547167b5edf5ccad5494c97ef32",
-        "dest-filename": "babel-plugin-polyfill-regenerator-0.1.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
-        "sha1": "fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
-        "dest-filename": "babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06",
-        "sha1": "0f36692d50fef6b7e2d4b3ac1478137a963b7b06",
-        "dest-filename": "babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+        "url": "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz#9ebbcd7186e1a33e21c5e20cae4e7983949533be",
+        "sha512": "76100f4c32c6a0c5b9ffce30920c222d1c0c9e2a368b57d47b9dc4bafb4a32fd299f6a774bc382a15d710337c93e5d0a397ec807cf6cda26fce6f6d889e6b78e",
+        "dest-filename": "babel-plugin-polyfill-regenerator-0.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2680,44 +2575,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz#747872b1171df032252426586881d62d31798fee",
-        "sha512": "62f76d9559bdb7793befb73934f408bfa73114515aa72b36e478949ae4a01f021985f89fc1e47973949fe67c04dcc01b7eedf6ec2612be9b3c631e8034bca579",
-        "dest-filename": "babel-preset-jest-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-27.4.0.tgz#70d0e676a282ccb200fbabd7f415db5fdf393bca",
+        "sha512": "34ae23198a6706f371706a3bfd9a5926be758c2193fb76f0c295480d8da835f4f124995d46d078540718760a759680c4e74383b93bbec818e9300b30bf9b65a6",
+        "dest-filename": "babel-preset-jest-27.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-10.0.0.tgz#689b60edc705f8a70ce87f47ab0e560a317d7045",
-        "sha512": "8ad2f6cfcbf5ea4869b8abadc79207f147427524eeceb3a14454c474886f799da2d6204a0eb544d004dae2c155cbed3618bb9c64d5415ada1aad7072d0cb1da6",
-        "dest-filename": "babel-preset-react-app-10.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-10.0.1.tgz#ed6005a20a24f2c88521809fa9aea99903751584",
+        "sha512": "6f40fd219d5686109692b4d7c85b88220a86cd2911207e43e40981d1b5dbcd8001d4e040c077147b2596d8ba2bbad2d61796ed368fcdeebfdc21d9afbca26562",
+        "dest-filename": "babel-preset-react-app-10.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe",
-        "sha1": "965c7058668e82b55d7bfe04ff2337bc8b5647fe",
-        "dest-filename": "babel-runtime-6.26.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
-        "sha512": "abf5048df189d829b7a0a57bd43273f5ddb94cf9eae6b84154bd90e1f039c1c0b78dcadd9fbf92b2c1326c5231c00bef3fe602b0260d2ae821a05df71b183271",
-        "dest-filename": "babylon-6.18.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767",
-        "sha1": "89b4d199ab2bee49de164ea02b89ce462d71b767",
-        "dest-filename": "balanced-match-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f",
-        "sha512": "e53e8fe313e0a69d180c5bd25b0119e0da04dda3384014170f39956eb6829058fccc733e99b6bc4b2a81e436d95b247b9981e8e98ec1750a373280389b44de42",
-        "dest-filename": "base-0.11.2.tgz",
+        "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+        "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+        "dest-filename": "balanced-match-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2736,13 +2610,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e",
-        "sha1": "a4301d389b6a43f9b67ff3ca11a3f6637e360e9e",
-        "dest-filename": "bcrypt-pbkdf-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/bfj/-/bfj-7.0.2.tgz#1988ce76f3add9ac2913fd8ba47aad9e651bfbb2",
         "sha512": "f9efd4a94cf09b325a98d179d2d055ead64f4ce468c3b810f7a885a30fbc6f9eb639d32910ad0170912ad8e48f1039806d230143b3ca67ceee6c5920c6961683",
         "dest-filename": "bfj-7.0.2.tgz",
@@ -2757,13 +2624,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65",
-        "sha512": "527ecc2040dd502e603697060d5f7ba29d58c24ef8f0ca477054c7a18b3aaa78f56778fb239dd51b79f06612b3a016666dd44d9dbe9645d165c25eed483b991b",
-        "dest-filename": "binary-extensions-1.13.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d",
         "sha512": "8c372d27f21541b6682729287876e15e93a5341a8635cc1724a268838d84e470cf53041349d8c21dd8a18e3d0396785e43b6e56d3e9d1ce69f340892f28a1028",
         "dest-filename": "binary-extensions-2.2.0.tgz",
@@ -2771,9 +2631,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df",
-        "sha512": "a76abfb7f9a1bee3a3fd478b955eb9eba183fe0ba8c25af4847c42948d16f66ecc59890bd45d212e8fb401ec6cf4748f0ad4754974344c3dcc30aad765a8db89",
-        "dest-filename": "bindings-1.5.0.tgz",
+        "url": "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a",
+        "sha512": "d56d3b70cf604ba0dc2e97ab65f1528fe6d62ed68f1923875a13e21b35e6bd525b44b746f36b07fca9fc12d5b556a595039e0029fda1e64e416e721bc05de1eb",
+        "dest-filename": "bl-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2792,23 +2652,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88",
-        "sha512": "73df017f7b4f9e223eb1cb1d936dfb92ed43737ba35d04d283288f50310e7bbb51921aeaae276f87c92506fd07084b28d4e2ce61c1ee0affdc4ba0cdc4a1fe64",
-        "dest-filename": "bn.js-4.12.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002",
-        "sha512": "0fb896441be7644f1e71788b8fff706f11fb4e4efd7c087c20769336ad515918b1b12d365bee6a4be884f72aba4589746ac5f1e6dc346cb8664f9a487db4aabb",
-        "dest-filename": "bn.js-5.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a",
-        "sha512": "76110fb3bd943db0e701027d64a30d4cfea9b496a2a2784fe5c05be78d675cf956eb425ea68f5157f6b87d7e17596f42b8534adb692b86b8f5fab83389f342b3",
-        "dest-filename": "body-parser-1.19.0.tgz",
+        "url": "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.1.tgz#1499abbaa9274af3ecc9f6f10396c995943e31d4",
+        "sha512": "f258df422e5e064f0425f10232b82a34658f118e6358ffb5233933906745144c05419672699db552a75a1e4b6088c947d312c7a8816d13fbb639813974eb5588",
+        "dest-filename": "body-parser-1.19.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2827,9 +2673,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/boolean/-/boolean-3.0.3.tgz#0fee0c9813b66bef25a8a6a904bb46736d05f024",
-        "sha512": "12aad3297417e99dc0da74663042250087e340e8059d53b69ea646a5b72c3e7606581c2916ace5ae8cd4d5dcbe4b68aa7d80cb876e9e7f82ab813c6ef7142bc4",
-        "dest-filename": "boolean-3.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/boolean/-/boolean-3.1.4.tgz#f51a2fb5838a99e06f9b6ec1edb674de67026435",
+        "sha512": "de1c74930537bb31ba45e437a6768540f4a4b69070e911cddff8af0ca12e53c8355d27da7e8c32bc39da763bf5c69f0866a86d4ae931970bfd6c5e85857f26d3",
+        "dest-filename": "boolean-3.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2841,9 +2687,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/boxen/-/boxen-5.0.0.tgz#64fe9b16066af815f51057adcc800c3730120854",
-        "sha512": "e5bbecab0fa1860522de86062b455fe16a489327a6a7ad160489e7efe58d7e8212cc0aa4fc75f82fb58d44eab7f04e9447fcb76000e9bfaa449b805f91e10074",
-        "dest-filename": "boxen-5.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50",
+        "sha512": "f6062040a5f1fb59cff263fb0b3172694011860ec3de7d5d17f16712b5a6bbd97a26f1a9354376efc8746926fe423a22292586fa2677b87adcaa4d2aad8f5141",
+        "dest-filename": "boxen-5.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2855,23 +2701,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729",
-        "sha512": "68d75b9e3f4ff0f8dd5d4e326da58b2b6205de373f1280d86c2ec06b35bab68dd346c7d7c6c702f545ce07988388442b93221b5a9d922d075ae3e4006bb9dcdf",
-        "dest-filename": "braces-2.3.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107",
         "sha512": "6fcba6f8bd51cccdd60d2cef866ea0233d727d36c1b7a61395c10a02fb26a82659170e3acfadba9558fd8f5c843d6df71f91fe94142964c3f593c97eefc1dad0",
         "dest-filename": "braces-3.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f",
-        "sha1": "12c25efe40a45e3c323eb8675a0a0ce57b22371f",
-        "dest-filename": "brorand-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2883,58 +2715,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48",
-        "sha512": "fbb0875ea1aeb29527fd297968eec46b4c56180b444cf5cd4808c7a38f097cb74f59c327837dd77b8ce716f4307aa73fbb3939cd2388dc7e760989e309f6f984",
-        "dest-filename": "browserify-aes-1.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0",
-        "sha512": "b0f864cf401129b7f8ad142dda14e9007aa7e3b5f79652e45069fec442732e3c18f0b46cda9d2fee58ef239132a113bf99ec6b36e9cd1028ac66cfa0c36cf3d7",
-        "dest-filename": "browserify-cipher-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c",
-        "sha512": "062a0ed717f7845c33e2473a881848de27831689a9321acc9670c50b8ff4fef779328929b8073747e2d86f04c0f40e5873da6af5460fa9f7caa56d8e6eec17e4",
-        "dest-filename": "browserify-des-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.1.0.tgz#b2fd06b5b75ae297f7ce2dc651f918f5be158c8d",
-        "sha512": "01d1044741e4b29827a36691f7b4807fabe2d32d24f0db8ea469d51f73bdf6b700e50eac87c43172782d1ee27ab97c277c05cd3381a7d466fbfcc575f9899ba2",
-        "dest-filename": "browserify-rsa-4.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3",
-        "sha512": "fefac0e5f82e54028a0154cd2638129b5b514031d453a0dbc0ef4844ebbfd160330bc3ca86e7034a1d7c27444cbd5787027e69b8c77e4070b67ab3d135ff259a",
-        "dest-filename": "browserify-sign-4.2.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f",
-        "sha512": "67de36472b075e626b86a93cf0598a055abfbf9b6a992903cfba79e06fcc1b28cc9c21459c2efd5d635b83e56d6bc5ba59bdaab526534b1206909ad1a4214488",
-        "dest-filename": "browserify-zlib-0.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.2.tgz#1b3cec458a1ba87588cc5e9be62f19b6d48813ce",
-        "sha512": "1c8e253ef786294474c764ad233fb61577c393d49f54caf19fa3cb87525e194c1cba80e474a65e6d68b22d127af2220f0e9308e092d50dfed2ed7cec96058e87",
-        "dest-filename": "browserslist-4.14.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717",
-        "sha512": "bc8ca15a622450b6aad381adf77b71761fa3d36c97fc9ce5ca12d86d5dd84029ffcef112dc99d8ed389f1c7befaf5c398530e5b8d28c915d3972ce2fcbc43bb3",
-        "dest-filename": "browserslist-4.16.3.tgz",
+        "url": "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.1.tgz#4ac0435b35ab655896c31d53018b6dd5e9e4c9a3",
+        "sha512": "bb6b5b6c6e4f74a45352872d3b73410fc150e4774f8756573c7ce9d6bc1a6b98d373e455f7ff9195688020a9a344f405fb16c633d2a4963e5b65015adacff7f0",
+        "dest-filename": "browserslist-4.19.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2981,9 +2764,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef",
-        "sha512": "3107171146c22ad128edb86a12ceb9eb41f27785daa2f6653bf93d57786355417fcf05bb28155d48ae2022dfdbcf04bd31b479aa86fe1798eeb19b1bd1840ad8",
-        "dest-filename": "buffer-from-1.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5",
+        "sha512": "13e5d0091c126da6a20a1b6fea4e83c2073e6f1f81b3abee2891c7979928c7f05a29b8625f3a903b02b870edb6c84946a763829a3c15853dc79b18323c69c97d",
+        "dest-filename": "buffer-from-1.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -2995,20 +2778,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9",
-        "sha1": "26e61ed1422fb70dd42e6e36729ed51d855fe8d9",
-        "dest-filename": "buffer-xor-1.0.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8",
-        "sha512": "c6afaadd244c3b11a2bcb84135a51d0bae210d34307a327e1f44ff341d5732d4d5130353adf145de00318b25b406eff15841a18d52a051c3210ab532dbeb825a",
-        "dest-filename": "buffer-4.9.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0",
         "sha512": "10773220f050e0148696f8c1d7a9392a0009dbb088b0763fd8906609145ea38f32f6b43731a533597dca56505ae14eccc97d361dd563d0aec2dd6681de3bbb15",
         "dest-filename": "buffer-5.7.1.tgz",
@@ -3016,16 +2785,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.8.1.tgz#d6e2b5f27723a7606f381e52a3000dadb1d6e4a9",
-        "sha512": "c47c40cddb0998c57c9bf37e20dcd850a7f224049e2b22879c0d6e1a463c63c24a2c8fdce011be21ff8bd087f66044eff7a0a24404a4bddd36b48b76a6fadc85",
-        "dest-filename": "builder-util-runtime-8.8.1.tgz",
+        "url": "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz#25f066b3fbc20b3e6236a9b956b1ebb0e33ff66a",
+        "sha512": "73c6bc277c0ae812152d6ee5b3eed344af6282ca536f35a652ac456e02b49b8d06826e9e7d46f1b565421888dcf9db5c872af9a8030050bea210645d4bfeafc2",
+        "dest-filename": "builder-util-runtime-8.9.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/builder-util/-/builder-util-22.13.1.tgz#fb2165c725b9405f0605a765cf91ec1870995ada",
-        "sha512": "80c7685bd6906d6631b90e24e234f8027d414e8fe15b3bec76fde9c0dcf5f223589ea9fd8fec4c96540e83d08781f41829251df15b8cb199db0af2cee0d96d63",
-        "dest-filename": "builder-util-22.13.1.tgz",
+        "url": "https://registry.yarnpkg.com/builder-util/-/builder-util-22.14.5.tgz#42a18608d2a566c0846e91266464776c8bfb0cc9",
+        "sha512": "cea2070c5270980ee357b482f5a23edf7316c13da65a88a31fe3a5f489ed340c2eb915e84beed7789c2784b0573a17030735d3e240f31e7464e0929e6b280460",
+        "dest-filename": "builder-util-22.14.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3037,13 +2806,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8",
-        "sha1": "85982878e21b98e1c66425e03d0174788f569ee8",
-        "dest-filename": "builtin-status-codes-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048",
         "sha1": "d32815404d689699f85a4ea4fa8755dd13a96048",
         "dest-filename": "bytes-3.0.0.tgz",
@@ -3051,30 +2813,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6",
-        "sha512": "cdab8b8eb7c21bec6fa326aa2e857c6cb5575cd182e09aa5c450aeb520d603a7c9ad3a3666ebcb613a99eda1c12d948c3a8a5bcf0bfc7fec19715cdf5532360e",
-        "dest-filename": "bytes-3.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cacache/-/cacache-12.0.4.tgz#668bcbd105aeb5f1d92fe25570ec9525c8faa40c",
-        "sha512": "6b4b4c078d2879fbee227af80b06f719eadb2fdc538f50f9ca0d13e71ae31821b27ef6f1b1e2175fb0403bfbbf8485dd69fcce239242df00f01f27f6e1bb8e01",
-        "dest-filename": "cacache-12.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cacache/-/cacache-15.0.6.tgz#65a8c580fda15b59150fb76bf3f3a8e45d583099",
-        "sha512": "8355980cc72dfe3cd6f897561328da5f6ce806467a653f55a4eca9d88fd532d0ec34b7df35ab7792a3c57e2d5e0d148af7f4ae286c8e4431dc40c70f17cb10ff",
-        "dest-filename": "cacache-15.0.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
-        "sha512": "00a71d4e71525804dde7f1823d1c6bd82870209f3909ecab1328d11e52b1439e9de1724c1b29b4b8088a9f4c5b2ce18e977fb24693938b8f38755084739014cd",
-        "dest-filename": "cache-base-1.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a",
+        "sha512": "7567b89d63bfaee10e63b1e4509e6016dd4308557dccf46826bf29574fc04907ab98e663b6af233233a9ac2d0a775d062cdfa5ef16943efc732455adc46bbc16",
+        "dest-filename": "bytes-3.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3093,27 +2834,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134",
-        "sha1": "847e0fce0a223750a9a027c54b33731ad3154134",
-        "dest-filename": "caller-callsite-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4",
-        "sha1": "468f83044e369ab2010fac5f06ceee15bb2cb1f4",
-        "dest-filename": "caller-path-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50",
-        "sha1": "06eb84f00eea413da86affefacbffb36093b3c50",
-        "dest-filename": "callsites-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73",
         "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
         "dest-filename": "callsites-3.1.0.tgz",
@@ -3128,9 +2848,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a",
-        "sha1": "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a",
-        "dest-filename": "camelcase-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5",
+        "sha512": "40e4af7af86c9628e0630471e91bfbcca74c17c95b466c7eb901b1dbebc373e288fde067b32f648ade5a8f6dc0806bb7a5ae2df408306e75d6a92fa2398fb668",
+        "dest-filename": "camelcase-css-2.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0",
+        "sha512": "62bc1a034bc429accf0649f48a94e232949a8d80d27be2a341fae385c04cc49b7fce76ef94777c3f0fd56a66b3e4407859f86cdd2511dd9f66c11bbf3f7b3762",
+        "dest-filename": "camelcase-keys-6.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3142,9 +2869,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809",
-        "sha512": "73bc15bdbc377f7ee7ba86d036d82c806f4f382f6a31b36e3109930aa66fdb76fa308cf47dc6290623a5bfd80437f85d2dd9d94c342183a7bd0eae4cd6f2af7e",
-        "dest-filename": "camelcase-6.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a",
+        "sha512": "1a6cba161625098eee3849595126f1a365020c7f28c0493df7a8246eba6c806b6b24b33727b8c6c65f4873b430c23e22bce13901665644c79c0dd17b86a1a314",
+        "dest-filename": "camelcase-6.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3156,30 +2883,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz#d79bf6a6fb13196b4bb46e5143a22ca0242e0ef8",
-        "sha512": "4cbd46ad2e55e8b1256e2b4f6b389d901303f6c6b8e3c6d00c32ebba60ea6a082628572e536256d704ce1c93ee90070e32d1262dc983244cdf46b7fe1a33343a",
-        "dest-filename": "caniuse-lite-1.0.30001205.tgz",
+        "url": "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz#d753bf6444ed401eb503cbbe17aa3e1451b5a68c",
+        "sha512": "8ae8cde3ec7b433a80d8d092ad2e55532fb880b991778c6feaf6c106c99f56a4f1f1b2c00fcd3dedeb8ba9080ac5254bbf18d20dcbc5d53fe2f687209d415ec7",
+        "dest-filename": "caniuse-lite-1.0.30001299.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4",
-        "sha512": "3e24ff850993a271e197f1c518df8bc772495339eb558277f8042c9ed8677996ef5bbc7e7f4f1393bc8b2532c4394bc14db76e2de78193111a61750e52b46aea",
-        "dest-filename": "capture-exit-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz#23ac613cc9a856e4f88ff8bb73bbb5e989825cf7",
-        "sha512": "ff86209d94bccb55175e60b4db10f9ad1ac112ee93e6e6fe9901cb3518f47f34d16e0741621b0da3657912ac20aab1318f1b23b45fcea402803242acc5b0f95d",
-        "dest-filename": "case-sensitive-paths-webpack-plugin-2.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc",
-        "sha1": "1b681c21ff84033c826543090689420d187151dc",
-        "dest-filename": "caseless-0.12.0.tgz",
+        "url": "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz#db64066c6422eed2e08cc14b986ca43796dbc6d4",
+        "sha512": "ae820538d85cc688342524966ef5408773a872e9264a0a6a387e98a4c902bdabffc92215dc92a0e0373cbd8b508d88bf531a4d137eabffdbfe56a4d0aa09189b",
+        "dest-filename": "case-sensitive-paths-webpack-plugin-2.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3187,13 +2900,6 @@
         "url": "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424",
         "sha512": "32d8be7fd96924d730178b5657cfcead34ed1758198be7fc16a97201da2eada95c156150585dbe3600874a18e409bf881412eaf5bb99c04d71724414e29792b9",
         "dest-filename": "chalk-2.4.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a",
-        "sha512": "ab0c75d80c577b6439c50e3701cfff23abf96974e2a58ad211274e833acdfbd5e3804a728e92aebd219a378a84f777fb4d04e57ab410f12f844341320e854bd4",
-        "dest-filename": "chalk-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3208,6 +2914,13 @@
         "url": "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf",
         "sha512": "916597cedbd9e5205057e79180a15e87cab9b0bb99636fbc5942339715954e0fa81b0635e2aca5c7529b2b31ddf0fe99624020d31c880d4f4930787224c6758f",
         "dest-filename": "char-regex-1.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/char-regex/-/char-regex-2.0.0.tgz#16f98f3f874edceddd300fda5d58df380a7641a6",
+        "sha512": "a06bb641e90131783240d58f0d1434d356e3bc39d97b8ff3053cf7ed331b88acf535b362ca21f98519286deee7a5137a19f6c66f131815c93fbd0d6bf5cd5530",
+        "dest-filename": "char-regex-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3233,9 +2946,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/chardet/-/chardet-1.3.0.tgz#a56ed2d9e4517a7128721340a0cb9a10a8fac238",
-        "sha512": "7324d0186a6d223213f823064f927fd25f5ce856fee7ae460858e37944cac543bbc37a11f8570d08c10a4e7e71b5529a2c59a569d37b405ebc22242cbf915b77",
-        "dest-filename": "chardet-1.3.0.tgz",
+        "url": "https://registry.yarnpkg.com/chardet/-/chardet-1.4.0.tgz#278748f260219990fb2167dbfb1b253ca26b41ea",
+        "sha512": "369c0c0dd488a6b6d8c7508b9df6f11086ab23467eb3d32cb0482080c36178633e583ebcc8e855ec8100ff7afab6bd324d18100f41ee6490f0df6b3df62e8bf8",
+        "dest-filename": "chardet-1.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3247,16 +2960,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917",
-        "sha512": "6666546b37cecdfd0dbdeeddba208a0f6dcf1520ace093e863271c8d4145dda42441a76a0617f3863930047da634e1bd71307085a98cdfb108b08919c379d182",
-        "dest-filename": "chokidar-2.1.8.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a",
-        "sha512": "f7eb3e39df96d15249cdac0399afe0bc1350aa44e2a984d62ee668c80b22bec23801a5930b31c6d3afd3323b1fd5c61ef426fded4084863cfb1ef9cf936a7fb7",
-        "dest-filename": "chokidar-3.5.1.tgz",
+        "url": "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75",
+        "sha512": "7a41a13a73553e04fbeebe0afd4dc60e1bbe150d92f139cafecd8a6c81978b44995aec2467640dc9f59d656f9355f9fce03a443fbacb782b76508e9b27c1b06d",
+        "dest-filename": "chokidar-3.5.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3268,16 +2974,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece",
-        "sha512": "6c8a26b43179286a5da2090b77d56ca6f17393d29fa72c86952f18155665ed318f0472f9b2720e9f17ac8705603ed790f5be04c9d97ea556c8c84d4372f09681",
-        "dest-filename": "chownr-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4",
-        "sha512": "f5eff3c758f0ec1e023be73f457a02b1f83fc7501f5018a8cb8a30607d1b269ac4600c7985114b461581a87006e7b0f464ce07eefc5b3fb6cf7b45708504580d",
-        "dest-filename": "chrome-trace-event-1.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac",
+        "sha512": "a772942f2420e12ecd2078b17706c65fe9c51e4a01880e18426c96b636fc5e7812295d76e27266472b2001eba36d455bd79be1f91bc551f08fa94eeb5e4fa166",
+        "dest-filename": "chrome-trace-event-1.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3296,44 +2995,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6",
-        "sha512": "755a915fb7cb526f09e85807278d7c5ee2200cb64391870315378be9303682de5694865442bac7e8466b3429704ff1f415ab5e52c66418838f46b2db3fe3d1f4",
-        "dest-filename": "ci-info-3.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2",
+        "sha512": "ae24ffdef239629547ebfaa89a50e7268c3a4c179ed8f04a484a71dcedf61063d86d618846c2251919acdd29bbe30604d49328f119ced381dbd76fafd49e480b",
+        "dest-filename": "ci-info-3.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de",
-        "sha512": "2a486de727ba6469b0bf8d2e503673b5ac93d9384b4067e78ff4fbd4dfd7cde65ea379dff1fa325bbcc64ec3d8904c9ade6e5fddc032a47faa7bb60eaccd54d9",
-        "dest-filename": "cipher-base-1.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40",
+        "sha512": "70e53dbac670f3f7572172adc1af29334393250b8993130deb0df472c35151eac77de43947a53792453f16d25e21fdccdb4d8e1df63653c71c227046effc6880",
+        "dest-filename": "cjs-module-lexer-1.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f",
-        "sha512": "b9cd958b1d5fad37e7bb3c71bb51e9e24b52bccdd0688e285e5e1952a2f5c234eefc11a48bd4eb096a2a2d383f76b4752b00046ab5ee445086d92bebd46c4f17",
-        "dest-filename": "cjs-module-lexer-0.6.0.tgz",
+        "url": "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e",
+        "sha512": "3a541d6d9ee02df19aad2ab17ac31eb036b9bb3eca15b203f0aa6afd2c48a0d183a98f25498b340fe861b415e171d077adc6d702b16beef94785e2e4d6fa1e34",
+        "dest-filename": "classnames-2.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463",
-        "sha512": "a8e84f6bf163eece9363c1fc7ac1aee5036930c431cfbf61faeaf3acd60dea69fef419f194319fe5067e5de083b314a33eab12479e973993899a97aeae72cc7a",
-        "dest-filename": "class-utils-0.3.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/classnames/-/classnames-2.3.0.tgz#19524334bad47ccd99793936b67f9be0860fe835",
-        "sha512": "5147ff4b779e7335c18c73e94a7ad9d59cb11f72a62d6f27558154588640fdd8b160c210afb97de3260ac5a02498f93b1cef5d953ea016a00f642d36b5375f43",
-        "dest-filename": "classnames-2.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78",
-        "sha512": "55c3160cde7864dfc34be839f0760be7f9f866ba9ef2f1c9a4603c29d8145c55387ee3ff687370f1e95df52c8423269b20c257ff445a63f7e994ea398582d214",
-        "dest-filename": "clean-css-4.2.3.tgz",
+        "url": "https://registry.yarnpkg.com/clean-css/-/clean-css-5.2.2.tgz#d3a7c6ee2511011e051719838bdcf8314dc4548d",
+        "sha512": "fde47caeee73cb12b3a412eff5866f317813492427ec0764308b4c6329ec1601b04ef7824556a6f4850f165a04f39078bc0223d3922e2a6984a15eff0108d3d3",
+        "dest-filename": "clean-css-5.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3352,37 +3037,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-1.1.0.tgz#2b2dfd83c53cfd3572b87fc4d430a808afb04086",
-        "sha512": "6c0b59a34bbcda009f68019f48dc5475323d98dcb36bb0fcc3809509c68eb32eec8300f3bf1e9e92be9cb9626a637506ce09d0d7ee3080436ea79788860c4460",
-        "dest-filename": "cli-truncate-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.8.tgz#ffc6c103dd2967a83005f3f61976aa4655a4cdba",
-        "sha512": "63a58ed2e9c0210a796cb9a4d7375385186026dff1de4b3a7f7d2cde81371f59a0204537dd7c908c47fc82c7fa0f10bb34f5fc6354ac3568d48cbff2c0b9e76d",
-        "dest-filename": "clipboard-2.0.8.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d",
-        "sha1": "120601537a916d29940f934da3b48d585a39213d",
-        "dest-filename": "cliui-3.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5",
-        "sha512": "3d87864849a61cceb3be879fdb0f133f396b9cda572234e2a582bbf3462cc2620ff6f8f199de98d9adc20762acebf014f0d1e366e817be8f30de858cdaa9f05c",
-        "dest-filename": "cliui-5.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1",
-        "sha512": "b7ac1b82da025ef033b2ded0817c4962a3edd2eb047db81075fb443db2cbfdcbefe873c4e5582fa82b80203474360539d9db3aac5c2aae06a434bac712309bad",
-        "dest-filename": "cliui-6.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7",
+        "sha512": "9fc7ce8b1c030fa6ff39b8a7cd3ae9d59285cdb82f299beecff4ef7a39cb9f56907c2eabe765c4c7ce459ae0bedc723e24cedca0145752f36a114d8f1d5ac7a6",
+        "dest-filename": "cli-truncate-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3464,13 +3121,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0",
-        "sha1": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
-        "dest-filename": "collection-visit-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8",
         "sha512": "41f014b5dfaf15d02d150702f020b262dd5f616c52a8088ad9c483eb30c1f0dddca6c10102f471a7dcce1a0e86fd21c7258013f3cfdacff22e0c600bb0d55b1a",
         "dest-filename": "color-convert-1.9.3.tgz",
@@ -3499,23 +3149,37 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014",
-        "sha512": "8e0228ba6d0e7d07eaf5685c7dcdb3fd584235c9908d66decbaa815f4beab7b60809f9549810a1f44f428900f919227e51e862c66dcd5301d586a5005918af66",
-        "dest-filename": "color-string-1.5.5.tgz",
+        "url": "https://registry.yarnpkg.com/color-string/-/color-string-1.9.0.tgz#63b6ebd1bec11999d1df3a79a7569451ac2be8aa",
+        "sha512": "f4caf3d8040b79f907d54bc048a8fabfa863ffb7968239d3fdc56c47c0ae9a278ba13fa0f74d1ec5678da20aadc1e23c7719685cdf410d04d8ae8d685aeff909",
+        "dest-filename": "color-string-1.9.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e",
-        "sha512": "c605c07131dad877850862c4f57b3f47cda1ba31adbbd25df71e0d5b74f7e3e38cb3b5683ec8f0cd1733287bd3007789c161705f98f5e7e320029a44f33b4e6d",
-        "dest-filename": "color-3.1.3.tgz",
+        "url": "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164",
+        "sha512": "68197b75923d10d37a7d4182ee65a93133cd1e659448d6a7f6db9637a6a187964b364f5b68b24e9d2325ad090772b7c5833dbf462823515023771dfa55c7a628",
+        "dest-filename": "color-3.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94",
-        "sha512": "30a18ccf27debaeb42fd927571b6bd36a70da5f7aa3147189b217564563afc29fb08d4802b1e9aface3cb2a2eac80899b9a3f64dca8c868a3e765c059d5c53f7",
-        "dest-filename": "colorette-1.2.2.tgz",
+        "url": "https://registry.yarnpkg.com/color/-/color-4.2.0.tgz#0c782459a3e98838ea01e4bc0fb43310ca35af78",
+        "sha512": "8474dcadbbc49c68c2ed604c93a89b4161550e01054d59a3af3d90e47954ea5b70c6fd0924dd99f08eee45b59e40b174e1d8a4c6cf338326646b3449bd232dc9",
+        "dest-filename": "color-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/colord/-/colord-2.9.2.tgz#25e2bacbbaa65991422c07ea209e2089428effb1",
+        "sha512": "52a6e0f89e38e677354ca9f81680cf4ba659a80bc40e7c2b1f8db2a3c078d0948e8122f1319fe0b778789e60ad3cb41e5e18c9264a81c7b482637e569c88b169",
+        "dest-filename": "colord-2.9.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da",
+        "sha512": "8547b0bfba0c8c2a7ec2406fe519b4bfcede261ab8c28879ad247ee3661240929e702aa022a36467a9409509acfc1c073c903934a311969c4f46fd27f07416ea",
+        "dest-filename": "colorette-2.0.16.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3555,13 +3219,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068",
-        "sha512": "34e2a6f31864cc08f3171f01dafe4e0074febb9a5141cd9409ad95abd8d82ffdf5a36c22f66c4103b2c816cdec5795520b8f73ea91217db3142ef4a12a3dba58",
-        "dest-filename": "commander-4.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae",
         "sha512": "3f40b2b0d0d0eebb55c3840842d9be311c55ebabca152be5b10bc6617656477a855348e530a1d9659830f1efbc0d26a1e140ca32a9e49d10d0cfec6e41743f66",
         "dest-filename": "commander-5.1.0.tgz",
@@ -3576,9 +3233,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937",
-        "sha512": "e8fea0d2e7ad1a95bfb1dc94cbf8904026c517491654c488552c98cfb6608dc821f26830f0f4330cd65ec99e4343680cecb06864f1e69e3cfcad4b619011b9b7",
-        "dest-filename": "common-tags-1.8.0.tgz",
+        "url": "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7",
+        "sha512": "42b59707e6504953e6216221b443bd1fe8301da3066221790a1be827e2bd6461c6fec56c6baca27ac003d460bfc78eac113d345e5c28d6ee3d455555cef71293",
+        "dest-filename": "commander-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66",
+        "sha512": "3a44cbf6e99ff877b60d9914abc7fc27da1fef22fa449288db875521306635f6419ab8bdcd8650aca92e5e22a1c9f3d2bbcb5486754107588a5debef9e54785b",
+        "dest-filename": "commander-8.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0",
+        "sha512": "404df7853a19b1e087de34b4a8df7a3bf6d287791ac3f87e4eaee783263d7960d49d3953354caa7eabc25e2a0b7b935ae6316c2fbf2b6bfc2e054e22b8481de3",
+        "dest-filename": "common-path-prefix-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6",
+        "sha512": "824fd9f39d83d96b5bfffd08fa444534a284f5d208562ae3a2a3e8035c0953e5de3d55d97c6781a64e39f80d6b28ee10e37a6ba9604d63f32221e44b6cf59468",
+        "dest-filename": "common-tags-1.8.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3593,20 +3271,6 @@
         "url": "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080",
         "sha1": "0162ec2d9351f5ddd59a9202cba935366a725080",
         "dest-filename": "compare-version-0.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0",
-        "sha512": "45ddec7ba401fac3b54f0a998ec710aeeae910f21f3b4ff26274a29fa43fac3de63aeb47bd4ac202126e6f7afdd2e35bf9211206e134418a01f7461d7dab6c46",
-        "dest-filename": "component-emitter-1.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/compose-function/-/compose-function-3.0.3.tgz#9ed675f13cc54501d30950a486ff6a7ba3ab185f",
-        "sha1": "9ed675f13cc54501d30950a486ff6a7ba3ab185f",
-        "dest-filename": "compose-function-3.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3646,9 +3310,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/concurrently/-/concurrently-6.0.0.tgz#c1a876dd99390979c71f8c6fe6796882f3a13199",
-        "sha512": "224f4882a9de7f638d2e3376a3f395c753b0e6dca656fbc4c10798090743fe857e08df685a1c4b93b89b70174eb6fd14cc1a87084291c1b29c798a132bcb777d",
-        "dest-filename": "concurrently-6.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/concurrently/-/concurrently-6.5.1.tgz#4518c67f7ac680cf5c34d5adf399a2a2047edc8c",
+        "sha512": "1654b03691a35907d1c0f2d7bc9fce832b1b0713e45a98958f2d74e366f453ba27ed2eeac3030820b463ed64cdd664e0a9ae7cd9b1ba345b9270ea21e9981d6a",
+        "dest-filename": "concurrently-6.5.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3660,9 +3324,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa",
-        "sha512": "6b578e21cbbcfbb95422781ee11a5ffe7e0aae47f70ddf65aa1963473208d7f667a3f911b545a7ce73cede338a0664c492d92dddf9318ac51c8afa23d1e6f3a0",
-        "dest-filename": "config-chain-1.1.12.tgz",
+        "url": "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4",
+        "sha512": "aa3f9ff003c04571eb33486b6aa5d86f6fdb395495e0fbc9425359fc3563d10ae634cdaad9eba2ce47ae55c910e7b27e5b49911fa1ef8be939d0ce09ba5d9545",
+        "dest-filename": "config-chain-1.1.13.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3674,9 +3338,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59",
-        "sha512": "80d95dff7972487c2e85a565b8950a2de3d88ab33740d08acd5c6a01d849208f7f5972955f93d447331526ca52d634ec952aa37ae1b828c5534a8ba2b7960f1c",
-        "dest-filename": "confusing-browser-globals-1.0.10.tgz",
+        "url": "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81",
+        "sha512": "26c3ca76687c6649a71f10e4e79159d53a952ef1104efa01c8965137d8f3234523c4afd08009aca61cfb3c6b6a80f89e419fc241c1d65c247b0130cd8467be60",
+        "dest-filename": "confusing-browser-globals-1.0.11.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3688,30 +3352,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336",
-        "sha512": "64c9183bf2e4175ed0bc23ea334831c3cc94ce28003993925921e0f75147ea8ad2eef7048f975565389d3767d0d78c8149d83ded1aa148dc0b517227779d8e4c",
-        "dest-filename": "console-browserify-1.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "sha1": "3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "dest-filename": "console-control-strings-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75",
-        "sha1": "c20b96d8c617748aaf1c16021760cd27fcb8cb75",
-        "dest-filename": "constants-browserify-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a",
-        "sha1": "fe8cf184ff6670b6baef01a9d4861a5cbec4120a",
-        "dest-filename": "contains-path-0.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd",
-        "sha512": "1313b4efbe2290439b200115f640e8e74a3eefd54251d101ea7ea5cca806c2ea5c55e46586b8f7a8601fc2af06eae0498e4a8bae14f4a846057169e0f33d73d2",
-        "dest-filename": "content-disposition-0.5.3.tgz",
+        "url": "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe",
+        "sha512": "16f7994cdb86c34e1cc6502259bce2eb34c02ff9617a16966d3b6096e261e3f13de43a8cc139a16b7299375680580f1c148847ccc654bcb7af930e51aa4fad49",
+        "dest-filename": "content-disposition-0.5.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3723,16 +3373,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190",
-        "sha1": "f1d802950af7dd2631a1febe0596550c86ab3190",
-        "dest-filename": "convert-source-map-0.3.5.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442",
-        "sha512": "e052645f3297103075b270856652cfe20a42dc920b89c0a919bcc6f5ff46eed1aa182cc44d0da158fadc8a703da14e30b5fd9b8946841f9d3ae549cc791df7a0",
-        "dest-filename": "convert-source-map-1.7.0.tgz",
+        "url": "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369",
+        "sha512": "f8e41d8cfe3dcd5888ffa8bb9c826903cac0978b15fc974f7d4f6766cdd5a8ec062208b3202bee376aeee9f31dfb89652f4b5aaf5f146095df67f4d6b668548c",
+        "dest-filename": "convert-source-map-1.8.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3744,23 +3387,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba",
-        "sha512": "f87a7c7cba79ef09d44add2d634b47117878be86510e7a08ad93ea968dc33e2238cbd97083f8eac7ed4e9bde3f5ba65a3c33946e78ceb7ff7dc3aeb393e9755e",
-        "dest-filename": "cookie-0.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0",
-        "sha512": "7f676899df5fb150c5b5a15c6da459b985f0b5d9a7cea6c00d2c21496631601fd0f33b1d51414c5d54705c60cc5a66c4cc09f591d46bb48d53fca4c538be17d8",
-        "dest-filename": "copy-concurrently-1.0.5.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d",
-        "sha1": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
-        "dest-filename": "copy-descriptor-0.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1",
+        "sha512": "670ac5906271511dc42285ed3bec9513af446fb2a58b16da78059f05007dbd5b0d9ffa3e630ebd8015924832bcdb985035d37ec05f3310b7f7745365fe4c6450",
+        "dest-filename": "cookie-0.4.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3772,16 +3401,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.10.0.tgz#3600dc72869673c110215ee7a005a8609dea0fe1",
-        "sha512": "f7255ec2e6f6317358c86bee2e730770dd64f5192f07bfe87e4b6978a4c86804b207cf1862a1b3527bb4cb030c849ac31ce3224e3487586cd1fa2ed66fd67591",
-        "dest-filename": "core-js-compat-3.10.0.tgz",
+        "url": "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.20.2.tgz#d1ff6936c7330959b46b2e08b122a8b14e26140b",
+        "sha512": "a99133550fb9421e9c44e6933c52cd4b8964bd0ea607313747a03a104a6cb23ed9af67a030782ccb85daa5d89fa890c60bd08188dbfbb3e7a323deab2cd40576",
+        "dest-filename": "core-js-compat-3.20.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.10.0.tgz#dab9d6b141779b622b40567e7a536d2276646c15",
-        "sha512": "082e7cd9e9e1ac5652b4ee05f25188ed02f7498c7bfc021173e21d4a2ddbb6b406ad5b136b0a392bf72b98a6d1ad0f8c38c84d5f8bfe3c04e7d24d8d37ac08ec",
-        "dest-filename": "core-js-pure-3.10.0.tgz",
+        "url": "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.20.2.tgz#5d263565f0e34ceeeccdc4422fae3e84ca6b8c0f",
+        "sha512": "0a6587bd22a7daf34bea9e92b4da751263087d563fa6a9f724b0237d943c59918f3a51a83bdd84917f7f324f358ba1b1be83d78d4a84427a4cdeb279431c483a",
+        "dest-filename": "core-js-pure-3.20.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3793,16 +3422,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec",
-        "sha512": "29bdb00b47efb167d0ae093c1d4e655ba53f2dcb3cfbd69a61ccb864573a0c3968e2767b9fbd1d120139aed474a06eae7ca0d49ebc1f58bd665d1e658c36adad",
-        "dest-filename": "core-js-2.6.12.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3",
-        "sha512": "310c7fed32e09a60d56a64b27c4f8efb9047bc6d5a5068ff80784b9f5c15b66d81e6ed5e5483ef87bbe47e3c1628d0a3ad3241f3e1def7d227b52435a8ffaf61",
-        "dest-filename": "core-js-3.10.0.tgz",
+        "url": "https://registry.yarnpkg.com/core-js/-/core-js-3.20.2.tgz#46468d8601eafc8b266bd2dd6bf9dee622779581",
+        "sha512": "9eeaa1ab5d4370e01b141578cc26ca7866ca42c50346a4d7d28ab1ec0b6d501baa7b7876d22c6c134dfd4077a56cbe8fe21fbd932b55ab212dc99ea0b22c0463",
+        "dest-filename": "core-js-3.20.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3814,9 +3436,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a",
-        "sha512": "1fae60b17a3548a8dff339ab27aede264f1a211295e5f7f60f8b8a6480594a16e1192a449ac40e3d6fd228c2988524eba91eee7f2e913faf6b3e881d68f87f90",
-        "dest-filename": "cosmiconfig-5.2.1.tgz",
+        "url": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85",
+        "sha512": "65006f8b50dca49e060ea6a78ee719d878f7c043b9a590d2f3d0566e472bbddc64b09a2bc140c365a997f65745929f5ac369660432e090e6c40380d6349f4561",
+        "dest-filename": "core-util-is-1.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3828,9 +3450,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3",
-        "sha512": "a689dd1af4ee5580e4fbeba98215c969b5b32fa2b1bba7f6ea58c5c3ae12c2af6feac40f50bdc4525543579e9d88e8e909ac8a8a12fa8557bc7b1200094e1770",
-        "dest-filename": "cosmiconfig-7.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d",
+        "sha512": "6b56163545761f01a2981edd536b35c1432eacd2a3a71eb41f1041eb150cf117bedacd60d4821f26f151d3f88217e5c7744d06313293b8b477d9441f7f84c4c9",
+        "dest-filename": "cosmiconfig-7.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3838,27 +3460,6 @@
         "url": "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz#ad60269c2c856f8c299e2c4cc0de4556914056c6",
         "sha512": "897de67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505",
         "dest-filename": "crc-3.8.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e",
-        "sha512": "99ff930b1f3059cf55a6ec5f3f686dd2248848b667b742605a5ace29988dab25195a78c868221535002b3079c264a7c461183a20cec0f8d789a0df207ff5acd0",
-        "dest-filename": "create-ecdh-4.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196",
-        "sha512": "cf4d1b0863470c6f261c090fec2b53d6a56ef9b15050f8d8abfe08bf70b79168d3155d74cc88df4a87aa5e8f40b30b3c8304870c68ff865daee0e1888daa5e0a",
-        "dest-filename": "create-hash-1.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff",
-        "sha512": "3091bd962899fa881ce13cd4c2ebdb111d4945d82f505481e7e551fe0e61f367c668845631675db4a0478bbfec5617e3419e927a197286f418adc6246942292e",
-        "dest-filename": "create-hmac-1.1.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3884,20 +3485,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec",
-        "sha512": "7f3e2ca4887ece78ced958cbf88761129449dd837ab0ccc84d20628e4e852b652f4eaaee4905befdc0994d236c32264dbd47aad02aaeac5f9d01bca218e63a5a",
-        "dest-filename": "crypto-browserify-3.12.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e",
-        "sha1": "a230f64f568310e1498009940790ec99545bca7e",
-        "dest-filename": "crypto-random-string-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5",
         "sha512": "bf5a65203df2f6bfe53e1be2275c2b5e92dec94206019d921cd61311aa66efff00f672cfa32bd5a7744afc43c5aa7e641339f25a061936c46d6182166ee1bc28",
         "dest-filename": "crypto-random-string-2.0.0.tgz",
@@ -3905,30 +3492,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5",
-        "sha512": "2c7cf7e47afcddd9c57a2a5cee8a850e6b231dd9638f74d0b7118688d5923ac4cb200b9b4a6e13133f2a09a285a64ee275a43519f5ac705e04ea6829072b00d7",
-        "dest-filename": "css-blank-pseudo-0.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-3.0.2.tgz#f8660f6a48b17888a9277e53f25cc5abec1f0169",
+        "sha512": "84e6f52c58d147ef28700d3bd715129a0e55b2527c346a3f236aa952975e018c8154282ea52e4ef12115a384b110c6321413687419331b74f58aa5bd1c25f17b",
+        "dest-filename": "css-blank-pseudo-3.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0",
-        "sha1": "808adc2e79cf84738069b646cb20ec27beb629e0",
-        "dest-filename": "css-color-names-0.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-6.1.4.tgz#b9bfb4ed9a41f8dcca9bf7184d849ea94a8294b4",
+        "sha512": "9697e4a92d1f72d726668b491a19f1908c895af057829ca2db0b0577827c541ef0cf2ad3e8287fdd0f8530d2698cae20bb5f863799213a7a54d9954aacb6e10b",
+        "dest-filename": "css-declaration-sorter-6.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz#c198940f63a76d7e36c1e71018b001721054cb22",
-        "sha512": "05cc5048a4d21044147ed6290559ec1f8485d39353b81a246f5f7fb01b7a6ac5c6299ffa54fecf2c6d420429050d83a785784f8748cc84eeb167bd686075c704",
-        "dest-filename": "css-declaration-sorter-4.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz#3c642ab34ca242c59c41a125df9105841f6966ee",
-        "sha512": "67c8677ec66ee28fe4b7e02e173786a4b56114e18ef6696ec8705a0366c0f1a0864f06a1e6c4f7595fdf4c71fc50d654cad388226b863eb97fa6b95be285f8a9",
-        "dest-filename": "css-has-pseudo-0.10.0.tgz",
+        "url": "https://registry.yarnpkg.com/css-has-pseudo/-/css-has-pseudo-3.0.3.tgz#4824a34cb92dae7e09ea1d3fd19691b653412098",
+        "sha512": "d200d858429a19a730c42aaf43762983ac06743d40ced6cc9b987526c69cb46da13f67a27e58fcd3c4084e6b9606913bb2348456b0256613d355dfe734c8ff85",
+        "dest-filename": "css-has-pseudo-3.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3940,16 +3520,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/css-loader/-/css-loader-4.3.0.tgz#c888af64b2a5b2e85462c72c0f4a85c7e2e0821e",
-        "sha512": "add7b38c28d2708aec2fc05262cce04f8b38efa21c34ab7ac97ebdb74a478c95673d44c3a67e167c8a43413377c0226f52f7eccff9858ee18e7a47f73d8dcd52",
-        "dest-filename": "css-loader-4.3.0.tgz",
+        "url": "https://registry.yarnpkg.com/css-loader/-/css-loader-6.5.1.tgz#0c43d4fbe0d97f699c91e9818cb585759091d1b1",
+        "sha512": "804cb6c3d02724d9c3f4aba8e1700ff557e55bfba32a84bd73fb323beb963259b98a073b2f2b0accf5da0e8476beba113a44b0b134b6b46af5c861846d939865",
+        "dest-filename": "css-loader-6.5.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz#6f830a2714199d4f0d0d0bb8a27916ed65cff1f4",
-        "sha512": "313bbafad32cf52dc452ace6a8b5c47203516cd9240ff4c616fa30a5ea16267e557eaec5320b26450b3d5f935701446238198ec66fe52e3b033570c4ea4f5b86",
-        "dest-filename": "css-prefers-color-scheme-3.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-3.3.1.tgz#5afc4507a4ec13dd223f043cda8953ee0bf6ecfa",
+        "sha512": "48703b1eefc4885d1d3b0766576f9a82fa98a46fa58e551aec3be7d4054e9921f737c28e111a1a33d946a6cb73f671aca138c0346c945ddaf197f13074c49c46",
+        "dest-filename": "css-minimizer-webpack-plugin-3.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.2.tgz#d5c03a980caab92d8beeee176a8795d331e0c727",
+        "sha512": "82fd0a40110cfaafd77682b2ce7a2fab7296ee870eee4f8584f3fe85047531e9c976ed2e3c64ba2196bd3f395ba81792e9771924d028aa8171940516e3ad42ac",
+        "dest-filename": "css-prefers-color-scheme-6.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3964,6 +3551,13 @@
         "url": "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef",
         "sha512": "0ea93b2d02a9c0ba07dd5a2fcd99e4cde82a352b80ce243235951cadd0cce34d6263e4793641815c69ad3b4e7fc9a5d0ce200bb8fa20786d1bed40208e74c94d",
         "dest-filename": "css-select-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/css-select/-/css-select-4.2.1.tgz#9e665d6ae4c7f9d65dbe69d0316e3221fb274cdd",
+        "sha512": "fda52c94a873913342414076a935fce255667e26bd3728cfdd6a431ad8ff5b18700735816145770e0529bab1d399ef144cf70f9400f50c9f9bd2737fb79d330d",
+        "dest-filename": "css-select-4.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -3989,23 +3583,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929",
-        "sha512": "a149e3996a72d27888df1fe63cbf1d54423597b3271b7f871f244f1dff981526cafacbce857a6648e703511521d9a382825da0af3ace3edd671cbb8254550b2f",
-        "dest-filename": "css-2.2.4.tgz",
+        "url": "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe",
+        "sha512": "6ab48c456208158d2157ca48c593047e6308e3b5a3dd1fda5a96430f159808f12238cbfab5f3ab9e90ed8310583c4403e15d18ffde7cfb54dd0b78964c57143f",
+        "dest-filename": "css-what-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0",
-        "sha512": "2ec4c047524f10cf53a46865ff4a779d079c0b62c9d240fc5f960046ed6193ff48d60ae2979bc3b4c672371704a71c438f7e1835c93fb9c8eea1477ae8ad37a1",
-        "dest-filename": "cssdb-4.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703",
-        "sha512": "32c0801b5cfd94f7683bf21430b481581495c55b49d77f79546210f8573680d76443584d0e741dc3762103bd56242056d6f7700347009e4fc39d6e9baa811462",
-        "dest-filename": "cssesc-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/cssdb/-/cssdb-5.1.0.tgz#ec728d5f5c0811debd0820cbebda505d43003400",
+        "sha512": "fefaa35e1bf5c7d786904ff33baa3c64e23b7607596cb54b506c9545b3e093a622a576d6f3b63350270ef89ae68b96f0265007ea80fe30d799c9181779ad4667",
+        "dest-filename": "cssdb-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4017,44 +3604,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz#51ec662ccfca0f88b396dcd9679cdb931be17f76",
-        "sha512": "c746071f1da1ea9d1f0a5d7363d2fdae80fbae7965b6e806bbbcd748a431ea4dab630d078b722ac5ca00185eeef50e70d67b7bbcad2e97157c2e8f84be5946b0",
-        "dest-filename": "cssnano-preset-default-4.0.7.tgz",
+        "url": "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.1.10.tgz#9350765fdf3c49bf78fac7673354fa58fa95daa4",
+        "sha512": "05ca52cd457280730e9e9f6e1b9adf3f34ce09bd06007424aad510c7c8f5a0c345f40d50f21ce238e8623386dd202a66ac1214f39044eb8443e57198b1541934",
+        "dest-filename": "cssnano-preset-default-5.1.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz#ed3a08299f21d75741b20f3b81f194ed49cc150f",
-        "sha1": "ed3a08299f21d75741b20f3b81f194ed49cc150f",
-        "dest-filename": "cssnano-util-get-arguments-4.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-3.0.0.tgz#c0b9fcd6e4f05c5155b07e9ab11bf94b97163057",
+        "sha512": "3f3b3bfc167a3a04feb575ee175d83291f129926f351e5580ad3016d2f25234b809b79ab626932a825d73ec404488ea498b7c4541a696dd558fde977860de700",
+        "dest-filename": "cssnano-utils-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz#c0e4ca07f5386bb17ec5e52250b4f5961365156d",
-        "sha1": "c0e4ca07f5386bb17ec5e52250b4f5961365156d",
-        "dest-filename": "cssnano-util-get-match-4.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz#b26d5fd5f72a11dfe7a7846fb4c67260f96bf282",
-        "sha512": "a8bb98b562b66f60f2e7923c657de4cb5675e9662cc79e3843451656279ba6da709ffc43066a20d932e0e1ff8304c835ac9e890d6b67f7a5876ce2835add5640",
-        "dest-filename": "cssnano-util-raw-cache-4.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz#574082fb2859d2db433855835d9a8456ea18bbf3",
-        "sha512": "59c2b1e4e63e2a8488031056e9404145acb553abe4621782763c953439bce73b792bd987a0639fb0eb2a22ccdf02aad04052082a08e1dbe1438088ffcec976d5",
-        "dest-filename": "cssnano-util-same-parent-4.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.10.tgz#0ac41f0b13d13d465487e111b778d42da631b8b2",
-        "sha512": "e709f2f85e87e3ff1180d95aa9a6f892d7377b4fdb94abad9aaf323650455c0fff9d214502a02782335547352f0a06113942e6659528a2c2ff292a19a3969469",
-        "dest-filename": "cssnano-4.1.10.tgz",
+        "url": "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.15.tgz#8779eaf60e3665e6a12687c814d375cc9f78db76",
+        "sha512": "a6966c4bba0fa62dac7e2c95e7e8be35b07fdc6b50f9a6f656cd5aceb65a5d6ba3512378a3e59d4f194264831c4fdc8b5b754eff9c97defa720da4359c89fc09",
+        "dest-filename": "cssnano-5.0.15.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4087,23 +3653,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b",
-        "sha512": "2b19d407464c9675160acc7667c314b2beaa57a8dad70f40acf12b25a25a17c6b948e5a81cb22ccde093286446460b4b818aecd44f021e43523f55594d33dcf6",
-        "dest-filename": "csstype-3.0.7.tgz",
+        "url": "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5",
+        "sha512": "daee38646d8e70d50ef470e9fc997c0b4ef1ea953f7934779dc57dd5288addd846f535af455b02a09c35e02931e43816933180df069958edddee982aa5423f5c",
+        "dest-filename": "csstype-3.0.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.15.3.tgz#8a62759617a920c328cb31c351b05053b8f92b10",
-        "sha512": "8e54ea0ef2dd1e760c4abd3cca735f9382005122602634cacb6539090052bb870df6f40e2689cb5593f8428e2028aac880843976bd3b530389762fa546a4f5db",
-        "dest-filename": "csv-parse-4.15.3.tgz",
+        "url": "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.16.3.tgz#7ca624d517212ebc520a36873c3478fa66efbaf7",
+        "sha512": "70ed48ff39b3e30d9d70a1d5be90abec9551bbcfc5ca61b9384a66bec65895c718a253c12e85462941e03687386469057859561840e633204cf934ea45d5bfc2",
+        "dest-filename": "csv-parse-4.16.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-5.6.2.tgz#e653783e2189c4c797fbb12abf7f4943c787caa9",
-        "sha512": "9f7ac855b5faca59b562c5f6344ba0f4868f57cc519d3fbdfcd3596eb03f6dc1e039249eaad5a56ba5e723fc66caee7bc08c3e012080a17d6833a119b6a255d0",
-        "dest-filename": "csv-stringify-5.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-5.6.5.tgz#c6d74badda4b49a79bf4e72f91cce1e33b94de00",
+        "sha512": "3e3890eb9f5a43e7d44d0a92addd571039ceaf9da3877d1106eadfce4b1c684dad3da16c0c7e703801c98b0f17007a614649c2c0c504f4a45ac9ce0afcd6cef0",
+        "dest-filename": "csv-stringify-5.6.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4115,30 +3681,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9",
-        "sha1": "596e9698fd0c80e12038c2b82d6eb1b35b6224d9",
-        "dest-filename": "cyclist-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a",
-        "sha512": "9bad9284439b437f427eb6a58a51104631faa0032d342575c49c84c792e945851537e12f8a984381473f17786761b0039a488db3aed8fb7ca59a51bb2e7bbe14",
-        "dest-filename": "d-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791",
-        "sha512": "255ae8cc87849678f74337d422df2d07c60c96e049a26e15c3da933e98c6610f5f6250770ffadbe8ea2b754c5fdf1785077e4b296b34c6a70ee54eb24af06dba",
-        "dest-filename": "damerau-levenshtein-1.0.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0",
-        "sha1": "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0",
-        "dest-filename": "dashdash-1.14.1.tgz",
+        "url": "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7",
+        "sha512": "b1d412141efe9657d47101d440edfe07c111463d0e6b8c3d3ce58c23fa6e1adb9fee0172c069a468b084967b9d7d388a655f8dbc7a8bd227f376b23c468ec448",
+        "dest-filename": "damerau-levenshtein-1.0.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4150,9 +3695,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/date-fns/-/date-fns-2.19.0.tgz#65193348635a28d5d916c43ec7ce6fbd145059e1",
-        "sha512": "5f76dfda24cf802010a7dc2f8ce432b677f9bcee6b1126115e53c855c8126ed4f939349c3dcb1ff5e654f81fd8224280b58af959e0a28b9f018004eb362b655a",
-        "dest-filename": "date-fns-2.19.0.tgz",
+        "url": "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2",
+        "sha512": "f1ddf9855886631fd01f489c1d809e2e6b0b98c52178c993c95f45726ea0bcdc1dc37d725d71fe3bce6c38127e38b9cb40c299a30be929be8580c2108dca6f43",
+        "dest-filename": "date-fns-2.28.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4178,16 +3723,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee",
-        "sha512": "76813076f9b83c278ae0add140dd990b60585016b1c0b0110aa666323b45f1ae7527645bd31a559681519c2383c2a8e9c270286a8e297a537c97744976fde045",
-        "dest-filename": "debug-4.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664",
+        "sha512": "ff3c70e7ebe1d537effb8427edae67b1b70928f692bc20e1a239fa14497dbeea702b6542483b44884b6aafc0c5b7360539dcfadcb064c5e73b0d8b9cda3a27e9",
+        "dest-filename": "debug-4.3.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b",
-        "sha512": "98ea7cc0a72f8fb5f10bbf332e0c3f640fba4d2824a04d82fe27a7b618510f6f7c4fb50dc0083d7620692d1c42d2639eccb978074c55eccd1c08ee8ffced1787",
-        "dest-filename": "debug-4.3.2.tgz",
+        "url": "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9",
+        "sha1": "d171a87933252807eb3cb61dc1c1445d078df2d9",
+        "dest-filename": "decamelize-keys-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4199,16 +3744,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3",
-        "sha512": "29a2fbfba170ea2e40d974a7b1b866ffa07e36e100ed3678beac67779b57cfdb1b2adacdf52ae3f1a6f8bca55d2bc600a993bd3f5920e3963a60ba1db8f7fe93",
-        "dest-filename": "decimal.js-10.2.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545",
-        "sha1": "eb3913333458775cb84cd1a1fae062106bb87545",
-        "dest-filename": "decode-uri-component-0.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783",
+        "sha512": "574a5f85fafcb2ecf23c63b1de79aae1a1ea69b7a15199fa0a1f64c85a55efd4c60d3585987a94a9775a6d1ed01eac73ad8a25178fad566261506e0e51183975",
+        "dest-filename": "decimal.js-10.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4216,6 +3754,13 @@
         "url": "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3",
         "sha1": "80a4dd323748384bfa248083622aedec982adff3",
         "dest-filename": "decompress-response-3.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc",
+        "sha512": "696df9c9933a05bff8a099599dc307d8b0a866d2574d1c444b5eef137868462a305369161da24a1644810e70d1f9c9bd27ef5085799113221fbf4a638bd7a309",
+        "dest-filename": "decompress-response-6.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4241,9 +3786,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34",
-        "sha1": "b369d6fb5dbc13eecf524f91b070feedc357cf34",
-        "dest-filename": "deep-is-0.1.3.tgz",
+        "url": "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831",
+        "sha512": "a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d",
+        "dest-filename": "deep-is-0.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4255,9 +3800,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b",
-        "sha512": "87ab0cad507554c595ad6d7799273a89afc3c18630e4c37af9ec4dbb539a25e15a73969202fc0cee56743557d3001b929107a5af8879a1e6e0dca0755cf76380",
-        "dest-filename": "default-gateway-4.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71",
+        "sha512": "7f048e26c6db37367f094169a8506a61f60d2e3d4d6cc3e6f0c3022331e30bcde248944110698353153e58febad4168140899e0b6c87c17b73f8ffcef68f9712",
+        "dest-filename": "default-gateway-6.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4269,6 +3814,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f",
+        "sha512": "0ecd3da8d87ccb0de48528e22638942276865fdc65a990d8ec956bc86c5dc55ecd3debaa41fa653a943aeb224566eb778cb6b9ccec245f0d60f44236b8a8783a",
+        "dest-filename": "define-lazy-prop-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1",
         "sha512": "dcca9f60a8f694bcdd3127fc648644fd5f99bb2f81803e9fd7ae1ef0adb0edd827a4a02b0437ab198a4ce3a21861c8e791d3cd3233e4f40e95141f3edd22a55d",
         "dest-filename": "define-properties-1.1.3.tgz",
@@ -4276,30 +3828,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
-        "sha1": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
-        "dest-filename": "define-property-0.2.5.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
-        "sha1": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
-        "dest-filename": "define-property-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d",
-        "sha512": "8f02b6515e1c9cfa5b706efe55101129364f516a30c1703c6f31f934feae774a1e031c983ee1995000bb84cba0a42773e01792665d8397d93ae821c9ff8e9961",
-        "dest-filename": "define-property-2.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4",
-        "sha512": "4301ae114a2e3f6915c107a702c3a87f916ff0af6ddc3f026bc3717172ab2291078d35cae49da75cb74ff802c8d5c82ff308fb2aec01853c0190e65224a3395d",
-        "dest-filename": "del-4.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693",
+        "sha1": "c98d9bcef75674188e110969151199e39b1fa693",
+        "dest-filename": "defined-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4318,9 +3849,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166",
-        "sha512": "2287e39180596998af9f457c9e7b0c24606be2354bc470e178a496f3c3f2c52e500b8568f596d956f873952c58f3b7d5ab749347aafee1c19ea721e47163904b",
-        "dest-filename": "delegate-3.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a",
+        "sha1": "84c6e159b81904fdca59a0ef44cd870d31250f9a",
+        "dest-filename": "delegates-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4332,16 +3863,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843",
-        "sha512": "434238a5f16bbf654f777e3fbdf2eb14ea119a5623dce579d22edfb24a6cd636562b5900a4c5964fd1ba45151e61e74b7010c8867483694bc931bdc085495a10",
-        "dest-filename": "des.js-1.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80",
+        "sha1": "978857442c44749e4206613e37946205826abd80",
+        "dest-filename": "destroy-1.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80",
-        "sha1": "978857442c44749e4206613e37946205826abd80",
-        "dest-filename": "destroy-1.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b",
+        "sha1": "fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b",
+        "dest-filename": "detect-libc-1.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4353,9 +3884,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.5.tgz#9d270aa7eaa5af0b72c4c9d9b814e7f4ce738b79",
-        "sha512": "aa2f3ab44ea145c147cbc8c8d66d951be2da3d44752e1a836b91bcb558ee51798eae9b8082ab00d69374fa5760af768a507f902c8f61098fce711622b0445e8f",
-        "dest-filename": "detect-node-2.0.5.tgz",
+        "url": "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1",
+        "sha512": "4f4348b90a674ef14301336e1cde6ba0fc12046f37ac5b2e3be3175c7f7fdcdd5e15b9f8c1c3e3b6dbe330b10f589d11194620404edc1a04b7b4dc5ba8218cee",
+        "dest-filename": "detect-node-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4367,6 +3898,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz#feb2a77e85b904ecdea459ad897cc90a99bd2a7b",
+        "sha512": "e92b08c7e9d451bb8ad04b612a3bf4ceb7676a30825d560699b6188988c5569cdc8f012cfc930367cb4f446dbd27f1e1379eaddc6269d9c1925834638e8b7c3e",
+        "dest-filename": "detective-5.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037",
+        "sha512": "831b727ea320ec62b285099bd39e8aeccdf1b33cbf9b21fcc3e078453f905c142cbc039d7375f29aa0c33c7c750603e0b1d000e522227e89daf3d62d4404c3cf",
+        "dest-filename": "didyoumean-1.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1",
         "sha512": "32ffd30dade767db1b739b282be3a803be01b12de62f7ef28b10af5004248ae0385b3e98b703ff2b8ee7dabbf6a2fcc766fa2241e03915340eb1c84a904c01d1",
         "dest-filename": "diff-sequences-26.6.2.tgz",
@@ -4374,9 +3919,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875",
-        "sha512": "92a6a0fcd97e7f71b0c8adb97e150c623f350543ab67d22e26c8c870313989c34cf452470159b755c503c5d2cfa10b53b94ca55a6e992249d8270c1a3f1b14ce",
-        "dest-filename": "diffie-hellman-5.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5",
+        "sha512": "62a890ce4aec987307e6eba1f0e750154f7f6690039f0ce697ccf43b91ef44d75afb9519b1a5ffc4df800317d1da15aad58ec76670333bd2799495ceb83cf65b",
+        "dest-filename": "diff-sequences-27.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4402,16 +3947,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.13.1.tgz#5a77655e691ad7e5d28fbf008c68e819e0e2bd69",
-        "sha512": "aa07cb3767e8e2adb021636f6dc2a567bd432d10cbbd620494e07ba31952c54acc8bac6123ef6fd4c87b134149fabe545e14336905da1aec8cb1045b1a0ad2c2",
-        "dest-filename": "dmg-builder-22.13.1.tgz",
+        "url": "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79",
+        "sha512": "f87972b728e53ca9c81bc5ee446f16be604ff31b3c3fbd72f9228a4ba6575a81202ee78fc6d0e8504887ed691d78f5ab439241a44e9aa15a9f65f2544248d7c0",
+        "dest-filename": "dlv-1.1.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/dmg-license/-/dmg-license-1.0.9.tgz#a2fb8d692af0e30b0730b5afc91ed9edc2d9cb4f",
-        "sha512": "46aeaa303683a2edbe68f376498cb4c7b2c3ce7a09fd7686ea80dc1f9c17529f9645640c51813a78cf85fa77b1fbf2d25cea75bb0e072c5a1e77461b7d4f11fd",
-        "dest-filename": "dmg-license-1.0.9.tgz",
+        "url": "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.14.5.tgz#137c0b55e639badcc0b119eb060e6fa4ed61d948",
+        "sha512": "d46bc5190137df66ef3da99c330643a96a9f59f253cb20cb3ac1cc7068b4cecf8987b24e9faff3b8190724858776c8f64096e1ccb572776fd9aadb4e2afec8f3",
+        "dest-filename": "dmg-builder-22.14.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dmg-license/-/dmg-license-1.0.10.tgz#89f52afae25d827fce8d818c13aff30af1c16bcc",
+        "sha512": "49579eca239e8a75792423c75cc74a3a02b56156da93fe3ef162f6ac19dfa9162903915a7856909d059bdb9c7adbc6a6d70ef409b8a9183bfd4b9d5b8a987adc",
+        "dest-filename": "dmg-license-1.0.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4433,13 +3985,6 @@
         "url": "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6",
         "sha1": "b91d806f5d27188e4ab3e7d107d881a1cc4642b6",
         "dest-filename": "dns-txt-2.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa",
-        "sha1": "379dce730f6166f76cefa4e6707a159b02c5a6fa",
-        "dest-filename": "doctrine-1.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4479,9 +4024,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda",
-        "sha512": "8e78f288ce9e472665d87f96f10ff32cc038f358738b47accc06815332159e66150c16e72f154d9dfbb51e0101bc26cbfbbd45af1325dc4ea5a4a1fb19edce5c",
-        "dest-filename": "domain-browser-1.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91",
+        "sha512": "e5ce78064e43c38a80c4d388d691448b33d28d5b31e7e6e924a98bda43e7f0984152adaad3db5309ade68e28ee9f635f2bbf0d328b8360d30190eacf6624be8a",
+        "dest-filename": "dom-serializer-1.3.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4493,9 +4038,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e",
-        "sha512": "2ec4e0c7f2f95690fe43c966b174875b65a903e781959f473dfddeac3d48a0f174d3fdc92876770649d4540d9018336eebd64d9b21660960523b8e578d8282e7",
-        "dest-filename": "domelementtype-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57",
+        "sha512": "0ed04ca3cda9bf5745b54987cabe3c6de8aeabbf764b1a21afef079bdce8c649583df6ba9f46770728e3d8857b6e6af6232a82967a844217e01c9279405d11e4",
+        "dest-filename": "domelementtype-2.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4507,9 +4052,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803",
-        "sha512": "2622b4e21d07b79bbff347dd2cc084995e3390d87605ca0c141999ffdd56b5867ca955d22a38b0edf5cc8053e71dc49980ea375dd8a71ef9a70d478c7f9478c0",
-        "dest-filename": "domhandler-2.4.2.tgz",
+        "url": "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.0.tgz#16c658c626cf966967e306f966b431f77d4a5626",
+        "sha512": "7c2d1a5cd417a8a4854ebdb00cd64386c1188c2898b035a5dc3d35930b76e619b56083f20c61efbe2debc3e3cba87025fe6ef531a885edde73bc1af4a79501da",
+        "dest-filename": "domhandler-4.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4517,6 +4062,13 @@
         "url": "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a",
         "sha512": "2e07765dc27f363130fbbb45bdf2b13b3098299b1d72de6573343665a418f038f3ee97c00f719ba7cc92256b6b78823fbc394c566c706baa4799dc48620b6d0e",
         "dest-filename": "domutils-1.7.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135",
+        "sha512": "c3de828e87e9ef63392088698e0a1b06299811fa0f8f1d55c740525fd3f7d1605d656d9620a5344f505dd24cf678d67d8a48ca8076c4c8ac7c041e87d4bde1dc",
+        "dest-filename": "domutils-2.8.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4542,9 +4094,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a",
-        "sha512": "f2c27bf049696c32411cd781cd46d454bb2a29d71c69afc15c5d6e3d3c371abbd04c182b42bb4e6ebda652b137f2fcd877c704bfe9bf2417c32e2a1871f5e86b",
-        "dest-filename": "dotenv-8.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81",
+        "sha512": "ae5062f5df23a6ff527f59253e335f140b960e328bc1320927f571b684f0211ea19d9c5c10e402660da820bdcc581630e46a540ca3849cd0fb2d74db229434dd",
+        "dest-filename": "dotenv-10.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4584,23 +4136,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9",
-        "sha1": "3a83a904e54353287874c564b7549386849a98c9",
-        "dest-filename": "ecc-jsbn-0.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d",
         "sha1": "590c61156b0ae2f4f0255732a158b266bc56b21d",
         "dest-filename": "ee-first-1.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba",
-        "sha512": "eef9aeca1e7e92e53224a78f8507d140185757909ef919da79e400acabb51003292f759b80cb79586eae419a4456f6124acc4c5d128e7b0b4393d45a4ca5d194",
-        "dest-filename": "ejs-2.7.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4619,16 +4157,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.13.1.tgz#419b2736c0b08f54cb024bc02cfae6b878b34fc3",
-        "sha512": "6a3948e342fad2a281071be97fbef491c8f11c071c329116a70b07029a72b65dd69968097ccbade16cfd55416ac8db57ffd6badb84136ad93a4eaa31a9ec11ba",
-        "dest-filename": "electron-builder-22.13.1.tgz",
+        "url": "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.14.5.tgz#3a25547bd4fe3728d4704da80956a794c5c31496",
+        "sha512": "37bde149b5c5cfa333e59ea1e82e65cba081f9d50dea4d4bb820c98c8f15178edb317bff404d0713e2a46f418f2aa4ea33b1ec93fc88617fa41c27d2911e451a",
+        "dest-filename": "electron-builder-22.14.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-3.1.1.tgz#7b56c8c86475c5e4e10de6917d150c53c9ceb55e",
-        "sha512": "8360f827a00f6e9b2221c9cb905332299e9b3a9109d0bb5c7369bae85ee8294ca6c8602deb6f0e59e53d9d166887570d994b3f6ba0a5b3651f3a6b19b44e3de9",
-        "dest-filename": "electron-devtools-installer-3.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-3.2.0.tgz#acc48d24eb7033fe5af284a19667e73b78d406d0",
+        "sha512": "b7751ccec62e826e0e01baaf74898c088988315745cc900781bc07a649798e67eed62cd581470ffe69eb3ea248a447822b5b991a9b7ec8781610dfbd130a1885",
+        "dest-filename": "electron-devtools-installer-3.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4654,9 +4192,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.13.1.tgz#7d3aedf988f995c149cc620aef0772559342ea03",
-        "sha512": "e67097867b2aad1c4fe4db19c542a388c91c166420957a7b8bf618e2ba77875b35a6c837bad38890cdbd67ddd84d25e2719254d49fbcf35d5ea391d7d6fa682a",
-        "dest-filename": "electron-publish-22.13.1.tgz",
+        "url": "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.14.5.tgz#34bcdce671f0e651330db20040d6919c77c94bd6",
+        "sha512": "87e34035175a0343ea185d7918abe8aec7963f38753d76bfcf1e08dfbfff3c8a245bc78a228bfc932db77e85126f9e591565071a9c5026ec7bcb63427c1b507a",
+        "dest-filename": "electron-publish-22.14.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4668,9 +4206,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.704.tgz#894205a237cbe0097d63da8f6d19e605dd13ab51",
-        "sha512": "e9ccf48ef6b09547b887901b7d05b13f36fef0bcd5cacc06016886737d8424499f8f7f474d0c8d3e42d78ab73bf8be31e48e91811933b9af11caee5066a73c70",
-        "dest-filename": "electron-to-chromium-1.3.704.tgz",
+        "url": "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.45.tgz#cf1144091d6683cbd45a231954a745f02fb24598",
+        "sha512": "73317d79856e3a6958fefc72310cf6ac694d4a3669c4d41805ed60990bfb6a5d7bd6a388860c8ef64ec3e402a581e4c248f2a4f8b1e18f967221d984b9bf6836",
+        "dest-filename": "electron-to-chromium-1.4.45.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4689,23 +4227,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb",
-        "sha512": "88b842e942de9ab9633d96fe42eb51e5340607ea5d5ba2860f94527a04bef2ca2b3994feadd4056ec405260bcddde46a3402ea25eaf8a10d7a62f247954f21cd",
-        "dest-filename": "elliptic-6.5.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82",
-        "sha512": "03c386e5247f8a3dd2b097560c97649126148d0742531e803d05de9b449a11e3c14918387b29866300642a8d58e8353e69ffc99f674142a0c1be39ebf558bc9d",
-        "dest-filename": "emittery-0.7.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156",
-        "sha512": "0b004b444210ecbbd8141d16c91bf086ae4de6a3e173a3cc8c3e9b620805948e58c83825fb4bf1ab95476cc385a8b83b85f5b39aef13e59d50a1f8664c8848b4",
-        "dest-filename": "emoji-regex-7.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860",
+        "sha512": "b837ef52356b7c62498729b1fe4cfaa6b96d7a7c35bbb5ab0a0d686bde33618f31c55a4b2d4bb4e392c04f47610d97571b9f3f1293cbff9900d7cd1f43faae76",
+        "dest-filename": "emittery-0.8.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4720,13 +4244,6 @@
         "url": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72",
         "sha512": "2f5f03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca",
         "dest-filename": "emoji-regex-9.2.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389",
-        "sha1": "4daa4d9db00f9819880c79fa457ae5b09a1fd389",
-        "dest-filename": "emojis-list-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4759,9 +4276,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec",
-        "sha512": "36ff66dfa4bfbf1a6c23e1dce3f64646cd27f665ea496186ab8f73c5bfdc25f3c040c6d4b6db4902534f4b8010cda05dc3fa4ab24c396cc6de913fd8ed6fd696",
-        "dest-filename": "enhanced-resolve-4.5.0.tgz",
+        "url": "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0",
+        "sha512": "10601b1af1fb8fb5edda773413b0fdf4b6b53a212cf0b9f28a6911830131a5431270de8efb7c7db485acecf2d0655371e180fed34b241d73d78b5c901e902664",
+        "dest-filename": "enhanced-resolve-5.8.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4787,13 +4304,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56",
-        "sha512": "7f62d9318975173bbb61204a83e46844e7a5a4e68dadc1a613d019b9b7837eb08489ae3cde85b8308e15c8577954d1c8810ffbaa6d48d305072b57899e7db2db",
-        "dest-filename": "entities-1.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55",
         "sha512": "a7dda27f9373eb5f48d30f9a909acb647d0c5f43dbe435f7f573b0413b5749d41039a607d374b5b88429e2684e66d017af1ab85623baed84e22c1a36eb7f28f4",
         "dest-filename": "entities-2.2.0.tgz",
@@ -4815,13 +4325,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/errno/-/errno-0.1.8.tgz#8bb3e9c7d463be4976ff888f76b4809ebc2e811f",
-        "sha512": "749ea806be5243555277daa493b0724606ffd521f82598c21d25bf9abeb7fd07173bdccb571bc9e8ecb5de78a8d37af1a529d50c38c5a2bef94a355e6563d6fc",
-        "dest-filename": "errno-0.1.8.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
         "sha512": "edd147366a9e15212dd9906c0ab8a8aca9e7dd9da98fe7ddf64988e90a16c38fff0cbfa270405f73453ba890a2b2aad3b0a4e3c387cd172da95bd3aa4ad0fce2",
         "dest-filename": "error-ex-1.3.2.tgz",
@@ -4836,9 +4339,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0.tgz#ab80b359eecb7ede4c298000390bc5ac3ec7b5a4",
-        "sha512": "2c9ccaeccad06bc4d2d236b6c3760d2f352024218f74f395d7256f7b38cd9d2f3d0fe551d3cf92cedda6cf7601d83724ffec39b5f22afd1a14005a89246336cb",
-        "dest-filename": "es-abstract-1.18.0.tgz",
+        "url": "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3",
+        "sha512": "daf27ab6303f51fa8b9b630fb3b8f15726cba01f22d6dd4977d4779084a5776d2c2313dc4db2ee82040e531796780bc852476ebff09f323ba1e169a25ebdaff7",
+        "dest-filename": "es-abstract-1.19.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19",
+        "sha512": "d47436336b0fb71c27bcebd3d590a51f24038a081d3635115a9636c1ee9a30a0908945714e656cd9460f2c8ac3f38b12fa431d5307c14b295b24fc0d9c1ae71d",
+        "dest-filename": "es-module-lexer-0.9.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4850,37 +4360,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1",
-        "sha512": "5ecd92b70e8d88d1d6ca9cd14d8d4cb5a1bfb899700a4f241fcd7ddb499af26bcdf17ab582c7e166fa642262d002bc3c0079eff0c4f6238e49ddcd11f2c944f9",
-        "dest-filename": "es5-ext-0.10.53.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d",
         "sha512": "526ffe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
         "dest-filename": "es6-error-4.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
-        "sha1": "a7de889141a05a94b0854403b2d0a0fbfa98f3b7",
-        "dest-filename": "es6-iterator-2.0.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a",
-        "sha512": "1c90c6c7975ac5e22fc5d071bc6d9c6fd838b44bf0224de2f3e9e15f4c86ad89995336e4760f106c37af85e0c1f20774fffb8f8f8735110b9af10f8c5624f4ff",
-        "dest-filename": "es6-promise-4.2.8.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18",
-        "sha512": "349e989f716e0e29c168145697fab95ffb3892844706b80a02efb2188e890817a2bb7aab71b261c13d86791fc45d57f295193c7694152682c41612be32edf534",
-        "dest-filename": "es6-symbol-3.1.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -4948,79 +4430,86 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz#ccff9fc8e36b322902844cbd79197982be355a0e",
-        "sha512": "6e9a00002f9845fcead1db1393eeaff5a1e6feeaa70f06b23405e578cca91a5e82a7123da175ec7151e8e1f9377893c89feaec6ed35eb41e2bfd9222745204f0",
-        "dest-filename": "eslint-config-react-app-6.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-7.0.0.tgz#0fa96d5ec1dfb99c029b1554362ab3fa1c3757df",
+        "sha512": "c72ca6a31b48b7510eb126866a0fbf8e6732c11ba2790a00d896cf0a39f0f47ba4163f7ff7b6863e8655162a1aa2dce4d4ae50b7db073b912eb596e4ac05d2d2",
+        "dest-filename": "eslint-config-react-app-7.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717",
-        "sha512": "a20b5ffb9001fcefa733a0c878150daf67ee4fba2df5083fd616ab05f06d68fd777a411615010430ff7804207bcda356de0c98fbc487605d34ae7a98c1729638",
-        "dest-filename": "eslint-import-resolver-node-0.3.4.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz#7a6877c14ffe2672066c853587d89603e97c7708",
+        "sha512": "22c513b46c45d61ac7ea531689297559b19a88fd35793ea4cf2c1d63553eccb73430ffa7c049d4892f5423c21a3935214de4092e50845886d720d047e1825b05",
+        "dest-filename": "eslint-formatter-pretty-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6",
-        "sha512": "ea3f71c5e81ba9ef3f91963c718a5ca74c616cad04809960de0f6689bdff9a22da131baec1cde7e5411f4a753a85631b4f4140615bc36cbf51ad182951e408bc",
-        "dest-filename": "eslint-module-utils-2.6.0.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd",
+        "sha512": "d049f4c34dcd455327f548b29fc6113c32af5a3c425a4b25504846353746c75e51bcf25843e95b3a5aab94d236bc402ce290d82b87ff1cdd936c39a4e533f48b",
+        "dest-filename": "eslint-import-resolver-node-0.3.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.4.0.tgz#a559526e56403cb97b470b524957fc526e2485fe",
-        "sha512": "3b4b348934f953162ea0ea4730b4883b6a99332beb6fdb21864d4433920d346b49d827dfadf526b2787a4d5b27a13e357e45c812774feb7d16368be1a0ef3bc5",
-        "dest-filename": "eslint-plugin-flowtype-5.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.2.tgz#1d0aa455dcf41052339b63cada8ab5fd57577129",
+        "sha512": "ceab9ea459d6098d8848c1700ff0eacda33ef87fbb3c3ccea54be8b495a6ff2d41005b79478a1e50b81dad37a32aa2e4cfb300fed82cb6c50c35873bc0d753ae",
+        "dest-filename": "eslint-module-utils-2.7.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702",
-        "sha512": "f0aec98c83473a91fae28ce4021a53dec77e16cc086537cc6538ddc74e76a675ab8110957e9f28a7db5b8e9024dc3754788fc16b80bc3a3742d2bf747ab1c43b",
-        "dest-filename": "eslint-plugin-import-2.22.1.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz#e1557e37118f24734aa3122e7536a038d34a4912",
+        "sha512": "757f25eaa50be8ef9f60fb6935189d782152a6658e515c7941c6862d5a9efef94388149ee2f6258c3583113c27c85ce997b072fd6548bbaadcae7882807f41a9",
+        "dest-filename": "eslint-plugin-flowtype-8.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.3.2.tgz#30a8b2dea6278d0da1d6fb9d6cd530aaf58050a1",
-        "sha512": "7227160ebf91bd300e292dd0fe4d37f99de876ddd50a259a98d50759de9059b55059c609c988144eef31d26c7d19f78312299ac14e64402fa7437305c4833a6f",
-        "dest-filename": "eslint-plugin-jest-24.3.2.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1",
+        "sha512": "fca241012545c69bb4c60d642019fd0146bc850567b33a70804ecb77494a025c7b21ef3bcb31330a04a47a4b7e95efd856189aa2c3b8635e060c039ce359dfc4",
+        "dest-filename": "eslint-plugin-import-2.25.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz#a2d84caa49756942f42f1ffab9002436391718fd",
-        "sha512": "d2b18f2416f01e818d3d4ef7fd008b3ffbef78c94cd5bd59f4fa689f13bcee37ebeadb87e658a05db0d3ea71d24b3042f28bd7d99f8142eec19390ff5e0abdce",
-        "dest-filename": "eslint-plugin-jsx-a11y-6.4.1.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.3.4.tgz#2031dfe495be1463330f8b80096ddc91f8e6387f",
+        "sha512": "0829f01bbd70bda6e6c2afea933d07588a811d0c70ea95c1d6eaaddb8771a89f56077e29560e3d6cbd6c8d7a619491e04cc5868418cdd4f89c772c43c6b7cfe4",
+        "dest-filename": "eslint-plugin-jest-25.3.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556",
-        "sha512": "eb6dd6122649ab147b55dc4508a2c8e9de8b2e9c099063d828e0e7907dc3ed6a4e1b928cf325ae78177c4cbb0d01eb4424d1798899a895a00a3b717ccb3c9505",
-        "dest-filename": "eslint-plugin-react-hooks-4.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz#cdbf2df901040ca140b6ec14715c988889c2a6d8",
+        "sha512": "b15085297f5f9655119d74f62702cde50828db8520e4d17a7718649b1b0c1146615d170683e5f77b525b27ce1878f40a065e44d198c01f9438ae475c198f7dfa",
+        "dest-filename": "eslint-plugin-jsx-a11y-6.5.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.23.1.tgz#f1a2e844c0d1967c822388204a8bc4dee8415b11",
-        "sha512": "32f1468598c8f19e07bac6a3992c34a2e806aeadc6b38bd3ff45a0c24b1981fe51acbad16b6a18030e7aa24538b59265f3e8fb21836e4ccfb6467144b9349d45",
-        "dest-filename": "eslint-plugin-react-7.23.1.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz#318dbf312e06fab1c835a4abef00121751ac1172",
+        "sha512": "5ec959cb42e7327fbce0d106f6348647a786a9a641df5df72fcc5ec10a377d06a06d0b86b7b6bade07fe3f53462996af118102dd45da584000fc0a8392e37ac4",
+        "dest-filename": "eslint-plugin-react-hooks-4.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.2.tgz#609ec2b0369da7cf2e6d9edff5da153cc31d87bd",
-        "sha512": "58098e0adec46c5d5733c5df6c228013300f9d2864352c1c22c003da31ddb0c513f666493e32c21bba4ccdb702f242b7eba34eb868a9f0728b0c2f97938c8874",
-        "dest-filename": "eslint-plugin-testing-library-3.10.2.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz#8f3ff450677571a659ce76efc6d80b6a525adbdf",
+        "sha512": "20e9452111f359f11040a7000f88b26039dd1f04d088231c255263c5e9a97f6d378e734b5275b7e005cbad5df7fa7117a227c91366441a672328f2fcf79ede4b",
+        "dest-filename": "eslint-plugin-react-7.28.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848",
-        "sha512": "a7b56eb4daf53bf42bc72b0ca37138e458d80d3797072d224e5b4f14d4aa28021f8c34970bee1d8fea9fcae0fc6df017ad6ff2ea55b73bbe9569834f29fa4aae",
-        "dest-filename": "eslint-scope-4.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.3.tgz#466ac181ecafc91f29c9346ca190b91d090734b3",
+        "sha512": "b4a67d1be1e720e9d80215dea010a2013f0b39d5379b556ab814cab015bfe7301a077d2fabb802eb40c86b23df309b7c119065a8f5731aa48de7bb081664ee9d",
+        "dest-filename": "eslint-plugin-testing-library-5.0.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.231.tgz#648b978bc5a1bb740be5f28d07470f0926b9cdf1",
+        "sha512": "7a01f3f40d561bb6fc092d31d4fe8ffd18f916a64e8eb6b2fd58e925ad78b4c65a95f44abe913638d277a6508cefe3dc8a7994e2d7266cf2efd15b70cd274b54",
+        "dest-filename": "eslint-rule-docs-1.1.231.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5032,44 +4521,58 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27",
-        "sha512": "c3de1d418a1abb2be50dce375e7181f2553766def5def342860b78116c215c03f65e406f9dd7f117402022a28e39ab233c83f38fd26a8309306c2603d3f57766",
-        "dest-filename": "eslint-utils-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153",
+        "sha512": "696c248674b4a805ea34e80a38ad1d2769efcc46e112fa72f0e949f6467415e66703ace98efd7f55e8bea6e185157ef390f0a41c75dbec80d7dc0fbbc8fad15a",
+        "dest-filename": "eslint-scope-7.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e",
-        "sha512": "e89ef637c50d6b8eb6c1afca14e0edfcf277214eb4483a42dd05c2d478dcd415d7a5f2f60bd479f8053b8e17b417a19112a54c87826ebbe358ef19fee9d8a951",
-        "dest-filename": "eslint-visitor-keys-1.3.0.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672",
+        "sha512": "bae402e3720672dc3af29240d5181b412f3f34feeb721e82c1de23dd906d828e3ff05963e1e184ed96126513778aae69554bfa18f756e59d511657a8f38b8b0c",
+        "dest-filename": "eslint-utils-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8",
-        "sha512": "42e76d4fa6afe565de96cf568c833bab3d570f57161af5f88065efa7fcc19fd9d71b4d83d2eb5d537126da6fd08d39ebb24e9b063982ca0977ae68f5d7c9ac41",
-        "dest-filename": "eslint-visitor-keys-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303",
+        "sha512": "d2b4a6441cd7803cc8b03ea619d2607afce07b3239df809eaf92ffbf2317d241f34ff8e2078de346177d61494c1982d0cb6ce9acd9a84fca9ab021ad63e41a2b",
+        "dest-filename": "eslint-visitor-keys-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-2.5.3.tgz#a125585a1d8bb9c939f2a920a9bc9be4a21cdb58",
-        "sha512": "2dec0d7af65ff608430b10864fa425b4d5958bc2886167382ca7229fc2bd033875872a46ed8026a1b503214ebb7c03daf9e323467538ae31242db608d70e7f50",
-        "dest-filename": "eslint-webpack-plugin-2.5.3.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2",
+        "sha512": "c96245a6ee03b63b162a4b7919e34106e64c94d71856ceaf4422e8095109ad38da481e8b0bdf20162a4d2bf7ab3361de83f13c9882be8571bfa4930b2be79164",
+        "dest-filename": "eslint-visitor-keys-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eslint/-/eslint-7.23.0.tgz#8d029d252f6e8cf45894b4bee08f5493f8e94325",
-        "sha512": "92abcd55b7648f3a45cb45ceb333708e42b367ee93730090fe1fa8ce57085b06a298106e8654389cdea46e23362fe3a30dcce7913271cd87d1147f76b31e1ad1",
-        "dest-filename": "eslint-7.23.0.tgz",
+        "url": "https://registry.yarnpkg.com/eslint-webpack-plugin/-/eslint-webpack-plugin-3.1.1.tgz#83dad2395e5f572d6f4d919eedaa9cf902890fcb",
+        "sha512": "c52b9cb244cdf6d3a47d6eeca3811a885224ba558b5f0081ff5e47f75ee547aa53bf4668b7afdf7ad16e72610d45bec9e70855485288bf09eb9ec6bbf121b6ca",
+        "dest-filename": "eslint-webpack-plugin-3.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6",
-        "sha512": "bf724234213ae2e9a41699a4146ab354ab0e4f4b4dd59afeb9ea8b65fa55d4e6fc7be08480f59af8ec42a061f7b6786298c2886819b89bfbda46927f92b473da",
-        "dest-filename": "espree-7.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/eslint/-/eslint-8.6.0.tgz#4318c6a31c5584838c1a2e940c478190f58d558e",
+        "sha512": "52fc5d389ee65c5970ee2b87640e239b33da52a230e78999aeff973d828d6ca74b4747ade2b7fad25219514f6488db67cf3333196c4c57eb50eee1bb246f033f",
+        "dest-filename": "eslint-8.6.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/espree/-/espree-9.3.0.tgz#c1240d79183b72aaee6ccfa5a90bc9111df085a8",
+        "sha512": "77fe670ac6f425caac484790cc567c0c7d519b13dc825456876e0415395412608aa1e85719da6cc744641c3b9ba9423c2d200828c429e2bf52cd0de7fac9b81d",
+        "dest-filename": "espree-9.3.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/esprima-next/-/esprima-next-5.8.1.tgz#e670c9e807dce91075160d7cd7735c4b74581338",
+        "sha512": "8cfba5799f63d3ae40f7118aade161f584a03e56cbf7f9a21bf9782ac964c046fb225c25e42b7b0660e44931c0d2b5b4aa7a8bc7e86c656201ebab355da300c8",
+        "dest-filename": "esprima-next-5.8.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5102,16 +4605,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880",
-        "sha512": "0716cd186366d11c9162f51d1e9230bfd216cde33d5c295b3b1c28013b8574e13b644eb01cbf874394fc8683ccfb31ef98acf3b04aa1832d06ad0e57d7769f89",
-        "dest-filename": "estraverse-5.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362",
-        "sha512": "4aa99900d2d64b49a76ada9b49f44fe60f0e5d90b5d85820d48c0db4bb321c3cc98b33915b89210df8cfa8966c7a63d6041daeab29146a1e58a50e9ea6ca82ff",
-        "dest-filename": "estree-walker-0.6.1.tgz",
+        "url": "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123",
+        "sha512": "30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004",
+        "dest-filename": "estraverse-5.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5151,37 +4647,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.0.tgz#00e8ca7c92109e94b0ddf32dac677d841028cfaf",
-        "sha512": "5522634f9a0236b16f092ea2823ccf02de61073436a8f04521b274df32c8f521349b1c19a4cc3a05f26b6c51e6d5ad78d406af30407c24798185601deba3df0a",
-        "dest-filename": "eventsource-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/evergreen-ui/-/evergreen-ui-6.4.0.tgz#5a0a88af3ca6ecce235d48edbf855f2ccfa07582",
-        "sha512": "751342c7639fd927b1df415c07398e240f9e8012c83563c8bb6866d8a2391776e92ecb30bcb7e2ded21f357379456c442bde11520b8f8052d494570fe44c5849",
-        "dest-filename": "evergreen-ui-6.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02",
-        "sha512": "fdfd86a384e88271ff2af08848fece52c1e7f39853f67524c7103d0445b1167f8e8fda3c64d2e6ff8d217658122f2b8e8a6b2b4ca2d4304a2b41ec69fda3d078",
-        "dest-filename": "evp_bytestokey-1.0.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc",
-        "sha512": "9d09fe848df2a7ea03d21b9884ac2f608df6f8915eabe5e435c0f5180a3763f323c6c7d51a6aebceb9f38d688d63a7fea5408fe38d1f4e1b05879819ad1014ff",
-        "dest-filename": "exec-sh-0.3.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8",
-        "sha512": "69d6f1732595e3aaa21f2bd2a79d132add39b41e2d2b71dc985eff9f17c07619e8c7cdec7930dbc276aa28ee2c5d1cbbae81c0205a893ff470fc0b846d7eb52c",
-        "dest-filename": "execa-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/evergreen-ui/-/evergreen-ui-6.7.0.tgz#c80cf3ecae34b8d7cdc40e751258144b43998bb0",
+        "sha512": "3aae07e3cf8029d23852f8c17705397d677de825303e8efd7b9503f38adc40ac301ebee0b122f7127b18b8b7df2390eff9346d97ce30d0bc296831d9e2d46545",
+        "dest-filename": "evergreen-ui-6.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5193,16 +4661,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a",
-        "sha512": "8f95b4fff5bb7fc531027f215d59f01bcb4bc1d894cb81492dc4aea4283a99a058643a7206f4c0a4aecacae2386ca8fc28e875af6607fbab9cb98b49bf56d364",
-        "dest-filename": "execa-4.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376",
-        "sha512": "a2feb0ff62c28aec8ee112d819da451a391cb34c0c4e0184f0fae44c78a4794cb98897a45f23c82948e27e4e42b04d29b7bb0c0ab319dd836aa028fa89d40e9d",
-        "dest-filename": "execa-5.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd",
+        "sha512": "f2e4a9659a1c01944100f20420d263dcba3d1f21a2b6595ccdcdbb121e586288e3305327f321cc0cc6941c4d89a9fab4e43ff0b9cc08e091944725edd6f721ca",
+        "dest-filename": "execa-5.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5214,44 +4675,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622",
-        "sha1": "b77735e315ce30f6b6eff0f83b04151a22449622",
-        "dest-filename": "expand-brackets-2.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c",
+        "sha512": "5d87ee28cbe3e0edf97ffa4e5cb39b9dd211bf243effee8084e0e1f8e2968fd4bde3df291c79ff20cb331fe82dd1f04245630d7e4d594a9e71dc089f9a7236be",
+        "dest-filename": "expand-template-2.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417",
-        "sha512": "f7f86538191097697f3cb1c9c7a263a0317ac4f29c244b1495629bdb7aca13b2b3783a9464a5ca34c5b6eca22e7b924c74157d1e09a824f71cf07b4ef39b7d20",
-        "dest-filename": "expect-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/expect/-/expect-27.4.6.tgz#f335e128b0335b6ceb4fcab67ece7cbd14c942e6",
+        "sha512": "d4cff490000b21a8f92da1baeac1494db46c5930039f2965cbcd9cbb86eca48d2797ea603f813a061fdaa9d1e54d48ee974e8aef14279eb028a9fc55534fbf6a",
+        "dest-filename": "expect-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134",
-        "sha512": "98727d3bbf51aa5ba9851adcc365ff19387793db55bfc61ca326382a487858331460a45952ad21d68d30dabaebc41a8ced5a1e515aa06f6ef19443174e762de2",
-        "dest-filename": "express-4.17.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244",
-        "sha512": "29ecb9348b14c5da8a837bc8b1dc3d752b97a4f090dbdef2eb00632f7d1e771c0f82dd84e3859c58165ecbf66f51ceac1112d3c4a7720aee206459946e4d50ec",
-        "dest-filename": "ext-1.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
-        "sha1": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
-        "dest-filename": "extend-shallow-2.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8",
-        "sha1": "26a71aaf073b39fb2127172746131c2704028db8",
-        "dest-filename": "extend-shallow-3.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/express/-/express-4.17.2.tgz#c18369f265297319beed4e5558753cc8c1364cb3",
+        "sha512": "a31971271710958c2a3d6295249b6f422c07828b07fcbacb48f03e1f8531a72bd24ba8c2e5a1fee4ca0714cf8a0018133add003ee7b8c3ae876bc8c2528f501a",
+        "dest-filename": "express-4.17.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5263,13 +4703,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543",
-        "sha512": "3666fa4179042ecb81af6e02252922968e941c781b7a42b95226607c4e941c3dc46f6ed80baa03f9b85c4feb49e9c97c766b20750c675a572bcbc92c04804ba7",
-        "dest-filename": "extglob-2.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927",
         "sha512": "c688791b55bf3c1d3fdbb95780c4322213f90d263f2e1a02b0ec9981bfba88c991b42c15068e79b8a68ca0462b0c2290856bea122a7964f28073a7853727ff30",
         "dest-filename": "extract-zip-1.7.0.tgz",
@@ -5277,16 +4710,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05",
-        "sha1": "96918440e3041a7a414f8c52e3c574eb3c3e1e05",
-        "dest-filename": "extsprintf-1.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f",
-        "sha1": "e2689f8f356fad62cca65a3a91c5df5f9551692f",
-        "dest-filename": "extsprintf-1.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07",
+        "sha512": "5ab937e5ef327422838ff02b0a5a3556b3d598df33a61e55e00b47c08b8786f317b0a7fbdd44f704e0fe6b30485bedf0389e058441fbcf2689085bc286362f30",
+        "dest-filename": "extsprintf-1.4.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5298,9 +4724,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661",
-        "sha512": "d83b457204faf308934e2c19da135d25f7073647bd5ce7e7c2605159786678a33cac5d131b0982fd0b68dd2ed1a192a9e5c8a565bc733b989335342c27e11e0e",
-        "dest-filename": "fast-glob-3.2.5.tgz",
+        "url": "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.10.tgz#2734f83baa7f43b7fd41e13bc34438f4ffe284ee",
+        "sha512": "b3d9c58459ef47adf096cebf90cf3c910a8384cbb401f763aa8b84da5e465503dba8b8321638d4e6bcbfaf6c8ab09c696fd3f2d4460daa2785ae631a5f8bfef8",
+        "dest-filename": "fast-glob-3.2.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5326,9 +4752,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01",
-        "sha512": "e295f0981a65b023eff05398d5645a905f7bd138cd1a71a77db3a72ea8e562f322175491df2387cb1311fd8097a4f4ceb29345e60c2e76a92d20fe15b1692f06",
-        "dest-filename": "fast-xml-parser-3.19.0.tgz",
+        "url": "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz#152a1d51d445380f7046b304672dd55d15c9e736",
+        "sha512": "1531558d8a013994c97a4894b1ac06b12615f502f403ecc3602463ef2df820ee8983ed8831812d41af9b6e272da5da55f1d1f15f2c2a53b0b48110c4385b4116",
+        "dest-filename": "fast-xml-parser-3.21.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5340,9 +4766,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858",
-        "sha512": "ec4733b3c8083c3ad5cd3f8492c60172ea6a332c521d75eb1ce2d1471536fc389c57cefcf4c441451f3e1dcdae5b352ea4eb38612e09cc1981c638c2541c43fe",
-        "dest-filename": "fastq-1.11.0.tgz",
+        "url": "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c",
+        "sha512": "6299295272bca1dd28d6199e49ced452cfde07fbc83d62588ca724d90288cc07fbd559b500043711bb99077836248cbea60f84443d2fa88efd2b26620767b637",
+        "dest-filename": "fastq-1.13.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5354,9 +4780,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e",
-        "sha512": "0f6cb86e8bd8a73ce21a06c762d182323949337eaf025ff2fb15329f50be155c7cb3377513ef3a2b0570e97bd84b338ff223299b55f4238c490fe42d51bdfa38",
-        "dest-filename": "faye-websocket-0.11.3.tgz",
+        "url": "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da",
+        "sha512": "0b36c297095702e891400954c9fa8f82f3e834a4dc9133c67f0655e1974085570fda587d294c498366f91a413b5db8ca4376099d0f73e83f67b4b02507eb4ff2",
+        "dest-filename": "faye-websocket-0.11.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5368,9 +4794,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd",
-        "sha1": "c4d598ead6949112653d6588b01a5cdcd9f90fdd",
-        "dest-filename": "fbjs-0.8.17.tgz",
+        "url": "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.18.tgz#9835e0addb9aca2eff53295cd79ca1cfc7c9662a",
+        "sha512": "11069614af9f10f4a889b8cdcbc23152d68538c5dc5ac63425a56b428651f730bc3766207fd8832133d68d44d521ac7de5be88ef8d8914ba804877ec6a0fef28",
+        "dest-filename": "fbjs-0.8.18.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5382,13 +4808,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e",
-        "sha512": "d1bb6723f1fc7f6a5abc630df30e349a548a39f4cad925499817c1795223de4370d2cc30833c91ab47794c954ec287459adbe93de58f37f30271fb961741336f",
-        "dest-filename": "figgy-pudding-3.5.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027",
         "sha512": "ec6a6cfd75b299b2e4d902d82b8373a4c3ab623321748c57b88bf2d9006c2c4ea58eea1d2af7645acfdca72249dc25485691f43a2d47be0d68bdb3332dd14106",
         "dest-filename": "file-entry-cache-6.0.1.tgz",
@@ -5396,9 +4815,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/file-loader/-/file-loader-6.1.1.tgz#a6f29dfb3f5933a1c350b2dbaa20ac5be0539baa",
-        "sha512": "2a5b7c0b80635925d84007e1a586241b8a873539dae2da0c1c46d6ac8e48b95a316d4eae88329e2803fdf51f2699b262de5bdec27fe34013a0538f8d4b7b4343",
-        "dest-filename": "file-loader-6.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d",
+        "sha512": "aa8de096ac936bad58b60e2eef71ae96d8c71a3751ca2837b46ea53edc97fe338426f1e27fdb81d3f3822362a27fa72d17771a4135b61b98329b6d6802c238a7",
+        "dest-filename": "file-loader-6.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5406,20 +4825,6 @@
         "url": "https://registry.yarnpkg.com/file-type/-/file-type-12.4.2.tgz#a344ea5664a1d01447ee7fb1b635f72feb6169d9",
         "sha512": "52cb103f966020e29e95fb1a0790ae1802fe63eabb12638dba2c05dcde47007d2ddbbaefaedb608ba45af64ffe0d5698f5417afb26f1bb9a4e5cb51d03c37b56",
         "dest-filename": "file-type-12.4.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd",
-        "sha512": "d19b7eb372fb55fd5b8b0599dbd6804625582f1ee23069c4525f71df77db07f8f78d1f35bbf3b62dba8af819b508348d0ca56d27f623c18ed351de5291e2d02f",
-        "dest-filename": "file-uri-to-path-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/file-url/-/file-url-2.0.2.tgz#e951784d79095127d3713029ab063f40818ca2ae",
-        "sha1": "e951784d79095127d3713029ab063f40818ca2ae",
-        "dest-filename": "file-url-2.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5438,16 +4843,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/filesize/-/filesize-6.1.0.tgz#e81bdaa780e2451d714d71c0d7a4f3238d37ad00",
-        "sha512": "2e9087b4f437b05c7aef3fae8761e74b25922cbbb9271a36d7bf79b910ee6abfc43ae6165e26f91263da18806e4a746a1f620e0e2280da4e6b7bf2bd3a737f62",
-        "dest-filename": "filesize-6.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7",
-        "sha1": "d544811d428f98eb06a63dc402d2403c328c38f7",
-        "dest-filename": "fill-range-4.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/filesize/-/filesize-8.0.6.tgz#5f0c27aa1b507fa7d9f72c912a774ca6a44111b1",
+        "sha512": "b07bd1a938b076672ecea7adee2570b1bc05e94ad5df02200dfd921cd758d47825f0f0b8e47660ff4c6d770e94da2cc857895c727ad8f5fb65eb064535d8d832",
+        "dest-filename": "filesize-8.0.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5466,23 +4864,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7",
-        "sha512": "4eae8f8b1134c3f54c15f0a06ce36792240856897f2492fb9d1322db47eacc0e0d46cf407dea8c19e45d3e2df0221624c63781696876af1c1aa67e53bb722a39",
-        "dest-filename": "find-cache-dir-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880",
-        "sha512": "b7618332dde8182feff81330ce6965583b8917fc5c0ed1398ff7c219ba830fb38bb89923d1c7e1d58480e5528fbf031e2c52cd0c193038a6765fce6318b55fb5",
-        "dest-filename": "find-cache-dir-3.3.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
-        "sha1": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
-        "dest-filename": "find-up-1.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b",
+        "sha512": "c17655e5e985123aeb89d220103d753a850a2f18988c072aa2dfcd25d0243a1949faf1b3c213807dc1b9397d633fe4b43dc8c49fc6dd309bfe8368f04373a78a",
+        "dest-filename": "find-cache-dir-3.3.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5508,6 +4892,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc",
+        "sha512": "efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
+        "dest-filename": "find-up-5.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd",
         "sha512": "d483276e3b782b3b107e7867ccd77cc141205d9e3823365a6669cb631ec3e45665687b76816db40ab8bc43e13fb79b488f8f9ea5306e6fed99c6efef3482f3a9",
         "dest-filename": "find-yarn-workspace-root-2.0.0.tgz",
@@ -5522,16 +4913,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469",
-        "sha512": "cc0a00422b9dcbeaf94af9d2c37289cb9a2cfe8449607cebce36bfb410eaad9b4d854c3c6edeb2f0e0733167235abfbc96257c11beb23a1c3c599ed5159e59cc",
-        "dest-filename": "flatted-3.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b",
-        "sha512": "755b0f03f53043cfb6ba815ee461ed88132ee3c7562d376cb8477b08a1a56650fbf2bd534d606f0ee15a146282a3f65f12bf79524e7abd9a17f3a3ac1e451e22",
-        "dest-filename": "flatten-1.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2",
+        "sha512": "f3fb0e6b0a3cb49e103815fc6254013312fcf912d97f13103a27fda342942933538cc6049563c4d2bfe6e55345c5345dd0d4b0f2a4b2f1d6a3af05f84582351f",
+        "dest-filename": "flatted-3.2.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5543,37 +4927,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267",
-        "sha512": "0d4825ebe1c3cc1d22129b4d4045cbc7f2a14e60dbf2d6541d278baa99e3a649d1ef41f49c2dadf4def704ae9f37884ebc9f38a4a94841543893914594179d28",
-        "dest-filename": "follow-redirects-1.13.3.tgz",
+        "url": "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685",
+        "sha512": "fa16f1a0b6c531b44a0f0a215fc1a44dab5a1aa3ba25bee31b0a40970832d9b233db95ed466eca13324cefa4755a2353e52c19917e18ef94b0068964a6613b89",
+        "dest-filename": "follow-redirects-1.14.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80",
-        "sha1": "81068d295a8142ec0ac726c6e2200c30fb6d5e80",
-        "dest-filename": "for-in-1.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.0.tgz#0282b335fa495a97e167f69018f566ea7d2a2b5e",
+        "sha512": "712d7bf18fb1c6d223114a2b70775d292ef208c96b0cf577d66b78edb94a2917cc77bd0ac6ee71aee005136a3db0363ac150b975eba86ffbbf6a50f4e186079f",
+        "dest-filename": "fork-ts-checker-webpack-plugin-6.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91",
-        "sha1": "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91",
-        "dest-filename": "forever-agent-0.6.1.tgz",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f",
+        "sha512": "4479012ad2d6515c1ded2a9122f099304bc0328194a745d4fac7908997a38f408ecf7448de158fe2c0afde065658b8c94ddeeb1b072c17978a6468a2d2bfe16e",
+        "dest-filename": "form-data-3.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.6.tgz#5055c703febcf37fa06405d400c122b905167fc5",
-        "sha512": "0d4c6e41a2a8a9f3677bc8a291dd78480921e6ec38fbcbcd89fa7a82603bdf260d4bacb02c85922c3fe7fe60731d04695b727badb01311a926880f09be44f267",
-        "dest-filename": "fork-ts-checker-webpack-plugin-4.1.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6",
-        "sha512": "d652ca07632edda18fd50ff67823b1d1f35b44c7bb5ddc24b703abba17eaa9dd2b2095b03780e1f84de1acf4a50c25e7491ed4b59d4ddfcad55e6fbaf8c12125",
-        "dest-filename": "form-data-2.3.3.tgz",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452",
+        "sha512": "1131249521a2e6dd10319ba25e803f43abdc9f170b40fe6f76e812a6e0328ba4951a2d9c94f3e9fb180486e31a1c2fb31a09f7d4a776df95b7e5fec7ca491ac3",
+        "dest-filename": "form-data-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5585,16 +4962,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84",
-        "sha1": "98c23dab1175657b8c0573e8ceccd91b0ff18c84",
-        "dest-filename": "forwarded-0.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811",
+        "sha512": "6ee446d1fa41b511d24c238049eea10f6e7cb44b9b16844b6f864d03a3713151cdc3680e7301e8f70c9a6e5ccccce039cfdc40f4bd4a36393f36de8c4fd698a3",
+        "dest-filename": "forwarded-0.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19",
-        "sha1": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
-        "dest-filename": "fragment-cache-0.2.1.tgz",
+        "url": "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.1.2.tgz#13e420a92422b6cf244dff8690ed89401029fbe8",
+        "sha512": "a36462250e8365a47fe7e4a2d2a254232eb7ed0311b9d4a2f6453f145cf1f4465aceb21d9c182953edec1160b1015847d91b715b63b3f93e29da8f2e38f55c80",
+        "dest-filename": "fraction.js-4.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5620,16 +4997,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af",
-        "sha1": "8bfb5502bde4a4d36cfdeea007fcca21d7e382af",
-        "dest-filename": "from2-2.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950",
-        "sha1": "cd3ce5f7e7cb6145883fcae3191e9877f8587950",
-        "dest-filename": "fs-extra-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+        "sha512": "cba380c284887fb1728cc22ff78bbe6f9add85e6448f347adc64f26499b9aa1e018bed988302c2708fdf3c56642f93d28b13ade9934a9bec3e1dfa7f05c8b0a3",
+        "dest-filename": "fs-constants-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5662,13 +5032,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb",
-        "sha512": "57f26038b1424be47a55cab4b250ae69e58474d0b7a2e0e524c348b1a707d95b402e2bbd995e0b3eb1dce5c0e5f24e5ac3a27c8f08165a9893a39458866233be",
-        "dest-filename": "fs-minipass-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz#0b7815fc3201c6a69e14db98ce098c16935259eb",
         "sha1": "0b7815fc3201c6a69e14db98ce098c16935259eb",
         "dest-filename": "fs-mkdirp-stream-1.0.0.tgz",
@@ -5676,9 +5039,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9",
-        "sha1": "b47df53493ef911df75731e70a9ded0189db40c9",
-        "dest-filename": "fs-write-stream-atomic-1.0.10.tgz",
+        "url": "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3",
+        "sha512": "7326e321f8a213ea535a271208b1474ab5d9e848a5177d2887dd450cff52d81d39d69ac46bb4167eb553426d74fdd0e9b300435d9ba03dad4e82ef1887e1d5d1",
+        "dest-filename": "fs-monkey-1.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5686,13 +5049,6 @@
         "url": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
         "sha1": "1504ad2523158caa40db4a2787cb01411994ea4f",
         "dest-filename": "fs.realpath-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38",
-        "sha512": "a166f567a9a41c8b242f3109fd7597d2cae4a644d0eef6a8a4c424c9a108a2ad1f9ad155c4eb616fc702c5e4fea77ca74dd924fd16706e01b86eb47905e5840b",
-        "dest-filename": "fsevents-1.2.13.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5725,16 +5081,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
-        "sha512": "de137b35ab2462f3032d0639e609d6dcd43e99eb0401ea53aa583e5446e3ef3cea10c055361cdc19861ea85a3f4e5633e9e42215ca751dcb0264efa71a04bcce",
-        "dest-filename": "gensync-1.0.0-beta.2.tgz",
+        "url": "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7",
+        "sha1": "2c03405c7538c39d7eb37b317022e325fb018bf7",
+        "dest-filename": "gauge-2.7.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
-        "sha512": "dedeab553a1ea197d848677c6282c54760c992242b22252b19c8ef157da60f0ddb9fa9363adc073744cd08b6c13bec3ca93be29a10e4bfe2d2b1c6c9635bc4eb",
-        "dest-filename": "get-caller-file-1.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0",
+        "sha512": "de137b35ab2462f3032d0639e609d6dcd43e99eb0401ea53aa583e5446e3ef3cea10c055361cdc19861ea85a3f4e5633e9e42215ca751dcb0264efa71a04bcce",
+        "dest-filename": "gensync-1.0.0-beta.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5781,23 +5137,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718",
-        "sha512": "035077061d5498bd1b89d33f617d8db023939c625e3cbf6b3bf33e330de6f5fda05297e8912d218b911a87459250459975984866d323908612ee60df3aa3476e",
-        "dest-filename": "get-stream-6.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7",
+        "sha512": "b6ce968beda3de3423aa2ef4c3902537c0c59e44b00be32a9b113374400b076a976585775ff6f50937e03cb18934c7805b174f7d4f053b59acdcd51f68708f62",
+        "dest-filename": "get-stream-6.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
-        "sha1": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
-        "dest-filename": "get-value-2.0.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa",
-        "sha1": "5eff8e3e684d569ae4cb2b1282604e8ba62149fa",
-        "dest-filename": "getpass-0.1.7.tgz",
+        "url": "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6",
+        "sha512": "d8499d1f562f210899a65b4236092e8949f2ba4cf133f47a343257df529edc11b536ae5bd12d8f857e7d50a8bdbd9a4f0d055daa7fb521c680c27cd34f9bc28f",
+        "dest-filename": "get-symbol-description-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5805,6 +5154,13 @@
         "url": "https://registry.yarnpkg.com/github-api/-/github-api-3.4.0.tgz#5da2f56442d4839d324e9faf0ffb2cf30f7650b8",
         "sha512": "db262a612e94cb86ebd67c340f756b9585b1b464e4521219aee981adc07029d04eccc4fcae801ef08bc8ea48c83a4c6ac5aa4a4791a412c1edcf70eefefa0ea4",
         "dest-filename": "github-api-3.4.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce",
+        "sha1": "97fb5d96bfde8973313f20e8288ef9a167fa64ce",
+        "dest-filename": "github-from-package-0.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5830,6 +5186,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3",
+        "sha512": "5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0",
+        "dest-filename": "glob-parent-6.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/glob-stream/-/glob-stream-6.1.0.tgz#7045c99413b3eb94888d83ab46d0b404cc7bdde4",
         "sha1": "7045c99413b3eb94888d83ab46d0b404cc7bdde4",
         "dest-filename": "glob-stream-6.1.0.tgz",
@@ -5837,16 +5200,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6",
-        "sha512": "2f06b1c3267bd8b93bbd920db4d36bcb05f466e2f24adadd0ed69b79f64a018e59189855b607739e5b917acc4d98f8ad1344803be3b6eac5931de292236c0c04",
-        "dest-filename": "glob-7.1.6.tgz",
+        "url": "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e",
+        "sha512": "9645f51c95f0c8c729af0ff961465cdacec3ae90221c1db5fd5f84d6b1d4ad5368924bc1e9ba8ccd3d157d5ebff3a64d69bb75935e18388693ee70ef397dc88b",
+        "dest-filename": "glob-to-regexp-0.4.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/global-agent/-/global-agent-2.1.12.tgz#e4ae3812b731a9e81cbf825f9377ef450a8e4195",
-        "sha512": "71a0258d1312fea703a3af57f417e482b8a1194806c78e056f84104e83508ec89687e62543aeaea98540740f0e96a8adfb9360d27933d3d8dedd9cc034c65c8e",
-        "dest-filename": "global-agent-2.1.12.tgz",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023",
+        "sha512": "9662dfea0b72acfabcb538d29ab3bde3005e41b151dc76cb1dbbb20faf70bb2424226a76856a8c181e3b397eb914190f7df3bae3520ff6359ad73e22bea1b6e9",
+        "dest-filename": "glob-7.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/global-agent/-/global-agent-3.0.0.tgz#ae7cd31bd3583b93c5a16437a1afe27cc33a1ab6",
+        "sha512": "3d3e9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1",
+        "dest-filename": "global-agent-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5886,16 +5256,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8",
-        "sha512": "056202bb3cc3bc3a07e78347282b1e0da9c0844dc2783a2b8032f9313e8b3175e3d960a777d502daccdd9380162df8dd80d0425cb51a9d761ca4104a392586c2",
-        "dest-filename": "globals-12.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/globals/-/globals-13.7.0.tgz#aed3bcefd80ad3ec0f0be2cf0c895110c0591795",
-        "sha512": "022a6ccfa64a4716bfc5091984d834a885974fac7aac3e3a7fac7f3c29c1a2696db5d23200f6a4e180fd8d398aa59ef6b91392314f3ba89b5c82980769572188",
-        "dest-filename": "globals-13.7.0.tgz",
+        "url": "https://registry.yarnpkg.com/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e",
+        "sha512": "b92f17ea548a37626e995a17adb533fae1b80581be7a26b0aa6dea15c4fb6a699f6d41de081a093251dc79cfd2de4ad293bdff004fdfd2ccd816680003791866",
+        "dest-filename": "globals-13.12.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5907,23 +5270,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357",
-        "sha512": "887f519a0c029942478b6cf9a36977793b4606d5de935398947adb731398ba0c872e602c66b3e3e373ad1d385deb606e87f56fe95c82043d9b77259c18d42aa1",
-        "dest-filename": "globby-11.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb",
-        "sha512": "7df766a2c8c0f34ef2efe940d4d3348c42c0455998ba5ffbd79c6220b123a378412cf4dc8ab8103675c40a7e60de6b51f1338b0956e47ee6b51e97a7db9fd772",
-        "dest-filename": "globby-11.0.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c",
-        "sha1": "f5a6d70e8395e21c858fb0489d64df02424d506c",
-        "dest-filename": "globby-6.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b",
+        "sha512": "8e121768ecf2d6c6fc232a1c6abb964a7d538e69c156cf00ca1732f37ae6c4d27cab6b96282023dc29c963e2a91925c2b9e00f7348b4e6456f54ab4fd6df52de",
+        "dest-filename": "globby-11.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5935,13 +5284,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50",
-        "sha1": "d53b30cdf9313dffb7dc9a0d477096aa6d145c50",
-        "dest-filename": "good-listener-1.2.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85",
         "sha512": "47b796a6d5ee198c708a3b34795fafde8ebe5c7d48a952bc74938479c41f4e6927730f4057875cc3f0e1c62f0c765a8fb61c71a59ca2ccccf283c453984b06f9",
         "dest-filename": "got-9.6.0.tgz",
@@ -5949,9 +5291,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee",
-        "sha512": "9d39c9e76f296eac586a78690d8b22e1177c30079a040ebbf91675d023359b76d30151440dc77902e0386ba5b9624199d623571f3673f13e9304a2de06e36b89",
-        "dest-filename": "graceful-fs-4.2.6.tgz",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96",
+        "sha512": "36d371a947178295b688cadfa927d1ef71a5b77f4af812f05ac3ecf78c91eb7bf8e53d166de8fb79198be5c59fc0482a5e79a3429df36894ec85d456fea0b665",
+        "dest-filename": "graceful-fs-4.2.9.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5963,13 +5305,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081",
-        "sha1": "f10748cbe76af964b7c96c93c6bcc28af120c081",
-        "dest-filename": "growly-1.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/gulp-sort/-/gulp-sort-2.0.0.tgz#c6762a2f1f0de0a3fc595a21599d3fac8dba1aca",
         "sha1": "c6762a2f1f0de0a3fc595a21599d3fac8dba1aca",
         "dest-filename": "gulp-sort-2.0.0.tgz",
@@ -5977,9 +5312,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274",
-        "sha512": "14d1e2ea69a81efb359b164076ce0fa5d092e901bc0780b592bc49b0cbad831979b77f869514f3cc8dcd12489f5f1da956c3af25d3864a62200e1439e45c1d3c",
-        "dest-filename": "gzip-size-5.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462",
+        "sha512": "6b1ed962899fea3a8f4d0e3e5c2a541b25ca1e4e56c1e4be7b4e4c04ee3fcb7589e519263d734abd7f9bc756de85520b570afa25242f64092ed36d421cf5c6dd",
+        "dest-filename": "gzip-size-6.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -5998,23 +5333,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92",
-        "sha1": "a94c2224ebcac04782a0d9035521f24735b7ec92",
-        "dest-filename": "har-schema-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883",
+        "sha512": "548641fa26c3871ece6e101eece56da046ee3f887f32e3931c9f89f21fde057a2d2589747c1811ef6c431422a0221db638964839537104c5ae840af5d2bf0774",
+        "dest-filename": "hard-rejection-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd",
-        "sha512": "9e64f64f49658dbc5d4197eca6c9e8f6182b1b7522afa2ace5a7e2b26eb6a68c6a04ceac0e7304b8f9b34eaf17374384c2a28b2dd8758d0237ab213ae8dcdbdf",
-        "dest-filename": "har-validator-5.1.5.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9",
-        "sha512": "5894deca9d09cc6b4772e32c8bbaf0d95c2d92f2daf89c9f10a2421727dc4b4f820e48d0e651cfbbbcc484564ff8f0d246b1205dae4087497531b81b138d578c",
-        "dest-filename": "harmony-reflect-1.6.1.tgz",
+        "url": "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710",
+        "sha512": "1c8a7f9f7f11f644230c4ce25f20d3b96defbe8c71cb18f11735cbac1af5f2e078ec69d2b7e1bd0f6f5faaba4ce5992ca4c70f202b9ddd7b01250e18d94460f2",
+        "dest-filename": "harmony-reflect-1.6.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6047,30 +5375,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f",
-        "sha1": "7b1f58bada62ca827ec0a2078025654845995e1f",
-        "dest-filename": "has-value-0.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25",
+        "sha512": "9058dc48d867946575932a0693b3972926b01f924e6ff2f351ce70f41d3684e4ced1d7c54636c740abe0d5de9c7f71db7949ad53d55b6d5deacd9d937a1f7b59",
+        "dest-filename": "has-tostringtag-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177",
-        "sha1": "18b281da585b1c5c51def24c930ed29a0be6b177",
-        "dest-filename": "has-value-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771",
-        "sha1": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
-        "dest-filename": "has-values-0.1.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f",
-        "sha1": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
-        "dest-filename": "has-values-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9",
+        "sha1": "e0e6fe6a28cf51138855e086d1691e771de2a8b9",
+        "dest-filename": "has-unicode-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6085,27 +5399,6 @@
         "url": "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
         "sha512": "7f676f3b4554e8e7a3ed1916246ade8636f33008c5a79fd528fa79b53a56215e091c764ad7f0716c546d7ffb220364964ded3d71a0e656d618cd61086c14b8cf",
         "dest-filename": "has-1.0.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33",
-        "sha512": "d67998a7fae1303884ec06240f0fa52f0940cf3d009ed1887b9d45dd17c57c4ab24377de636788fcd7300baba621054e0123ccb1624b2527162924afccbf4854",
-        "dest-filename": "hash-base-3.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42",
-        "sha512": "b5a39ab241ade33e1238034db1e3af8980ef8c42629c8911826a7b2db28fd984d3995c56065f3bb3fbb32bdafee3805c9414a9d97ecad61a9e35fcfd25b05e5c",
-        "dest-filename": "hash.js-1.1.7.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/hasha/-/hasha-2.2.0.tgz#78d7cbfc1e6d66303fe79837365984517b2f6ee1",
-        "sha1": "78d7cbfc1e6d66303fe79837365984517b2f6ee1",
-        "dest-filename": "hasha-2.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6131,13 +5424,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e",
-        "sha512": "97db1f0c5b2eaad3aa283b1076aacc464d14f3945973446d391f723c8ee645539ae05b11fc1567674b2199044cf7a262f7d91864fffb867d5c79d735f80a6c4d",
-        "dest-filename": "hex-color-regex-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68",
         "sha512": "08ea66ac5d8d3a0e13056509e5457268253603cf3010c9143cae2136ac8292a1dbc53f7605bbdf8e84a8ce4008226e978627069491e115dba59489eb761c14f1",
         "dest-filename": "hey-listen-1.0.8.tgz",
@@ -6145,16 +5431,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.1.tgz#a8ec4152db24ea630c90927d6cae2a45f8ecb955",
-        "sha512": "4ba1bdeed1c6a89fd4f03b177047670026e2aed6f1e7c071f42cc855e6258bc3aeb3009f608fcbb171f612219ca068a8d4a002df1e26994c2e94e96527667244",
-        "dest-filename": "highlight.js-10.7.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1",
-        "sha1": "d2745701025a6c775a6c545793ed502fc0c649a1",
-        "dest-filename": "hmac-drbg-1.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531",
+        "sha512": "b7371415aba2b1628d1da4643785a397f640d3b8043408c597727f738f34769ae4193839110b2d81a345a817d4a82ab9e2465120472b793b00805fe6daab83ec",
+        "dest-filename": "highlight.js-10.7.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6173,9 +5452,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.0.2.tgz#5e425507eede4fea846b7262f0838456c4209961",
-        "sha512": "73d3865db67782e0bfc4e9428350a2fd5816970b2a0efd723102f5096a970cbd210e35ee35cab4cee478c6a3d2b9ab08de4a850e1a92c938d1133e60cead1f5e",
-        "dest-filename": "hosted-git-info-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224",
+        "sha512": "9320ae10e5a326a66e0db447ccbf15f77373421c0807bd681564b2cd5a3e28f648fa99d03cfc6e71d92b399be42d19eb7f9511b1033e209d3d0f0dbd71100b20",
+        "dest-filename": "hosted-git-info-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6187,27 +5466,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e",
-        "sha1": "d49330c789ed819e276a4c0d272dffa30b18fe6e",
-        "dest-filename": "hsl-regex-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38",
-        "sha1": "c1ce7a3168c8c6614033a4b5f7877f3b225f9c38",
-        "dest-filename": "hsla-regex-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7",
-        "sha512": "3fe33ae50636250e58d06f4a29d943a68d332befce1e9b54e40681c147c02032599353187f7d85ae6f3811c3b2b5f244d2de49be40272a59a3b170e75b308999",
-        "dest-filename": "html-comment-regex-1.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3",
         "sha512": "0f925b38c04847f4d5664b9b1d3f8ec93dbbd3942fa20516e08067ea71ddef9e8ec2279217d6836058f876fe871c454661b1da2c44dadd6820658596332cb765",
         "dest-filename": "html-encoding-sniffer-2.0.1.tgz",
@@ -6215,9 +5473,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc",
-        "sha512": "f27c6370171df30a2f6de2b1ee1df04e38b87bafab85a56e3cda4cab05a09c787e37d4e8aac0ace97ced59104f43e52dceca0c01d299b5410da15cd4fc432d64",
-        "dest-filename": "html-entities-1.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.2.tgz#760b404685cb1d794e4f4b744332e3b00dcfe488",
+        "sha512": "73701bfeeae5e64b1a4f45b295eb25a4112d84ecd686b8d06e0ef9cbb5d4b1f4b38b70e0cedd25f30e5eec3ca5467d7931394c303e7c7537f375d352da47008d",
+        "dest-filename": "html-entities-2.3.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6229,30 +5487,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#922e96f1f3bb60832c2634b79884096389b1f054",
-        "sha512": "64faf930d39baa757f4fd6a4b213ca6d58323aa2e6cbe071a3b8ee2827d37e78cd9e24c031dcb8873db5610aa8a1f301243da475111aa8f3dd4e1a11efc4e0c6",
-        "dest-filename": "html-minifier-terser-5.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#bfc818934cc07918f6b3669f5774ecdfd48f32ab",
+        "sha512": "617c529490594cfed14b7b569d0c3be28a0a6ba2fd6fd8bd4185d8db579412f859deef572dfbfa3a716c42ae91c64847ca0b1a50cbd8b19455e6b53f395359c7",
+        "dest-filename": "html-minifier-terser-6.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz#dc5670b7292ca158b7bc916c9a6735ac8872834a",
-        "sha1": "dc5670b7292ca158b7bc916c9a6735ac8872834a",
-        "dest-filename": "html-parse-stringify2-2.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2",
+        "sha512": "2a49c9e7491322727ba8849c1778de68546932913cfe57e24ddcdffedc17c8f04b006acb4539a4cf701d4e729e878d17f24f4bd9f758c04a7fe365865c844672",
+        "dest-filename": "html-parse-stringify-3.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.0.tgz#625097650886b97ea5dae331c320e3238f6c121c",
-        "sha512": "328ba85c46128d3cc2ae32315b083c8312f97c4d97d966492e60585e5689850507e4afdbe4eaea995ed3e1d07b8aed3192627a26552e57a7c556d9ea6cfa2967",
-        "dest-filename": "html-webpack-plugin-4.5.0.tgz",
+        "url": "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz#c3911936f57681c1f9f4d8b68c158cd9dfe52f50",
+        "sha512": "b32f3c3c2d9c453571bc44d18141c5acbe0da37531bdc1fc1b535ea4686a6934fe1973769136a6a9ab28b748a74b98577a0d5c31b143b76ef3ce8f69df995957",
+        "dest-filename": "html-webpack-plugin-5.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f",
-        "sha512": "22089e3628d431b903a2fca828e6d4d435219b58b035813f7ee89f1281077ddd6864a64368e3414a46a5ed8d35b21c6c338f51e1768c7467b3dd69c5f547e209",
-        "dest-filename": "htmlparser2-3.10.1.tgz",
+        "url": "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7",
+        "sha512": "832c8f93aae0a272c51031a879181035a114bdd27892d4e699487f876b7bb3e33ca0fa483f180d00259afba112479ee45ecb70a8f882badd15f0d469730814ec",
+        "dest-filename": "htmlparser2-6.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6278,30 +5536,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f",
-        "sha512": "b94401b771ff7122157dc87a8b512e3cdcbf62c4523940574d57d9fb247b6637b3dea8c1cfa8bdfa2e338cd6a8a9ca05548e25409e69960eb74ef19f4520c246",
-        "dest-filename": "http-errors-1.7.2.tgz",
+        "url": "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c",
+        "sha512": "2a993d4a6ecd988f911e19e3e8e2160c8d5de9f228140b45b7d44b693311960ffcc38f63b804adb2b060a740e9e0e7717556d121e2a1b4252fa22fd1b8084ee2",
+        "dest-filename": "http-errors-1.8.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06",
-        "sha512": "6534d7d0c5abb10d9902103571e8c0c032f2705b1dec8ee756d9e44f73a5d1aaa875a296fb4093643435b81bf9c21a6d0a773c7bc1de45127146cd249a6fd07f",
-        "dest-filename": "http-errors-1.7.3.tgz",
+        "url": "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.5.tgz#d7c30d5d3c90d865b4a2e870181f9d6f22ac7ac5",
+        "sha512": "c7e2551243b63e833caaaa5b3db38bddca873f07ab7a9ecec332bb032fac3108cacda282a96be3a179b9b6a30ff6d5d65939d3cc08c885783e27df5762e3e13c",
+        "dest-filename": "http-parser-js-0.5.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.3.tgz#01d2709c79d41698bb01d4decc5e9da4e4a033d9",
-        "sha512": "b7b863bde7ffe4710aed1593754cd552197cce412ef8b95a134218cdd32ebdb4838a9c414693a7e14870f19c840846bcd3c8954fc5c28f3a3ac6662de0288b66",
-        "dest-filename": "http-parser-js-0.5.3.tgz",
+        "url": "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a",
+        "sha512": "934cdd360a964c603a69e211569bdf5686f87cbe767537da7a1ca583463852f4b24af3aafd8f813b23eb82952b03b1f296abd4f2f2191ac46e5e6b29b245744e",
+        "dest-filename": "http-proxy-agent-4.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a",
-        "sha512": "c876138163103bc56fc0d4b6d9e2cb968024bee9e0b0a74a4cb3bc00995fb5820a35f26bdc62b7ccad1909fcc30c6501b6d74673cc45cb59828adbcd290b42dd",
-        "dest-filename": "http-proxy-middleware-0.19.1.tgz",
+        "url": "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz#7ef3417a479fb7666a571e09966c66a39bd2c15f",
+        "sha512": "71f697455a19c5279dfc19a403b4b0055348f4a8fb1c596d684e6ba983ae6f9916cd667e8287d5da4a153758f6acc5bba447d24a5087189df5c66bb21727cb3a",
+        "dest-filename": "http-proxy-middleware-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6313,23 +5571,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1",
-        "sha1": "9aecd925114772f3d95b65a60abb8f7c18fbace1",
-        "dest-filename": "http-signature-1.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73",
-        "sha1": "ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73",
-        "dest-filename": "https-browserify-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3",
-        "sha512": "48442eeef97c2a334bd9ea0604b177fb0023a6c35f03d5cc9570188ffdc475a35f025c4ab610f5c631107c6394865942186255358df86d1afa94f20d84d8f267",
-        "dest-filename": "human-signals-1.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2",
+        "sha512": "124626e4170a50689dbb1cd2b77129a64a3e3e2356344a5ae324a4f6f4c2eb00ec4095bdac749af94846349a11629edbcfa1edd5e69121ae90689a8ee6b0856c",
+        "dest-filename": "https-proxy-agent-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6355,16 +5599,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-1.1.1.tgz#1d8028926803f63784ffa0f2b1478fb369f92735",
-        "sha512": "44591fcb5d2137126a73b315029e62019ab44ee9ba9ac04235e6c47b739e94e06fad13afcc750f691f107b5d1142b386a244e6d16e2f246109cebb85904b7e85",
-        "dest-filename": "i18next-fs-backend-1.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-1.1.4.tgz#d0e9b9ed2fa7a0f11002d82b9fa69c3c3d6482da",
+        "sha512": "fcc7c018c3f48c7a2757debab857fd3e4596b838cf60b21cb22a6748edcdc6936d02045428b4f0be6f397c49ac17a8467aed336d98824375bbe23c0ee8af6e5c",
+        "dest-filename": "i18next-fs-backend-1.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/i18next-scanner/-/i18next-scanner-3.0.0.tgz#16024fa7f6dc5fd73d91545bd01566f86a76529a",
-        "sha512": "726e0287756a89c1994bccbee314af5e83ac9c4fe25a11d98ba0191320202cb9b710367f798db58036cb7db9f029563ac02821cc010ef4b7d1365c704e8f0a31",
-        "dest-filename": "i18next-scanner-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/i18next-scanner/-/i18next-scanner-3.1.0.tgz#35d00d945637c1a2b90124b0fd327040ac197598",
+        "sha512": "7472d750922217509824db250a42450d82724a4e5f83e773760f4eef75d7a8771d670276f78ed25aeb2aabc1dd34507b2e99018bca131ba4d62d93e6a9b021f1",
+        "dest-filename": "i18next-scanner-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6376,23 +5620,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/i18next/-/i18next-20.1.0.tgz#397dce9ad230ea822f487dc62d6128df5b678456",
-        "sha512": "b15f99c13338224e1deb029dc0d4bfa1c2a6bd78ba0c503f6073207505f78b82f9f7dde39dba35fe3d692bf738fb304e8dec5eaf876df9ce491ec163e025285d",
-        "dest-filename": "i18next-20.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/i18next/-/i18next-21.6.6.tgz#65db9a32e4746d145b3ab3f12c59fc02ad7b5101",
+        "sha512": "2b53f0f0afa71d5728e7a3cee94aea36ae0afd955b6f67aa050c0faa6cd80e6e2d190617063773f23ae7bee36f579493684f281a958a40cc473af876ce1544ed",
+        "dest-filename": "i18next-21.6.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/icon-gen/-/icon-gen-2.1.0.tgz#401642b68d7c79316a8e6729bcf3fdfcdb71bdfa",
-        "sha512": "aea215beaf4c27c5fbc27256d0d3bc11abbffb945657b007e8be6f12dfd4e408efe5679f743343c46c09846a24c87bb2056797ec9a91310d37b46d2001ca3812",
-        "dest-filename": "icon-gen-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/icon-gen/-/icon-gen-3.0.0.tgz#7b23f75e24a6a8f3630910dfc546008f0247d7a9",
+        "sha512": "283d73c4dd7471b9cc483406be3aee785df4faf3bf13ad46f22352f8b07cc6795859c6e1354a03b863cc63ffe8dc4bcaacfbd1b602a186ffc779ef649ff6c4af",
+        "dest-filename": "icon-gen-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/iconv-corefoundation/-/iconv-corefoundation-1.1.6.tgz#27c135470237f6f8d13462fa1f5eaf250523c29a",
-        "sha512": "d4d05ee790bbe5b28665a63d507c6f5c6dc6d20129d338a1b7baae86e16b5b748f8190f0f4723aaaf61745257933f12ea72bbc963b89e826daf9e735e4f6785f",
-        "dest-filename": "iconv-corefoundation-1.1.6.tgz",
+        "url": "https://registry.yarnpkg.com/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz#31065e6ab2c9272154c8b0821151e2c88f1b002a",
+        "sha512": "4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5",
+        "dest-filename": "iconv-corefoundation-1.1.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6404,16 +5648,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01",
-        "sha512": "db2f758793a9425a2579f30f994962bde962b6d496cb4acffa8615a67e80ec6c151cd13c016ce860e04d9a5c24b372e86da2718070986409f2368d8682935135",
-        "dest-filename": "iconv-lite-0.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501",
+        "sha512": "e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33",
+        "dest-filename": "iconv-lite-0.6.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467",
-        "sha512": "e1a16aef0bd6c8c1ca831b07f1042d1a9bdb01209ff9e337c0f44b23a47e3200274c267a49362c46fb6d2ef4562b435f89fe69885dfde12b771de2436a58c63c",
-        "dest-filename": "icss-utils-4.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae",
+        "sha512": "b281617e509558b7d134e3d4de2bf967d554753e38c4545bce32ec1334abe4042682a3cc4c7754dcf313d427f5b2cc7c7cb3490c0d63b9fb5897e3d472fdcca8",
+        "dest-filename": "icss-utils-5.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/idb/-/idb-6.1.5.tgz#dbc53e7adf1ac7c59f9b2bf56e00b4ea4fce8c7b",
+        "sha512": "209b6e8292a48955d09f963e2ed7b2042364d4df31a46577c16664f4456d6561fc0d8923067d1b5f55e718ff51932645d2c01ccb06baba71ea49629eeeae0b1b",
+        "dest-filename": "idb-6.1.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6432,13 +5683,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501",
-        "sha1": "c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501",
-        "dest-filename": "iferr-0.1.5.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043",
         "sha512": "3e0b3de7591a326e465cfecc3afc4444835ede0b1a563516166f9464f4aaf7162b890024b32860d1cb274b429748d443e4d98d75aa571298f11b8f7e00a87fba",
         "dest-filename": "ignore-3.3.10.tgz",
@@ -6453,9 +5697,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57",
-        "sha512": "04ca5f0fb3e98844e9065fc0e92e3df0168827a63f0014fddc44db6f2d9f3f4d2fe046ef3c15d6128691d5404f2acde2479de9258ec4b59939280088e7b8b553",
-        "dest-filename": "ignore-5.1.8.tgz",
+        "url": "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a",
+        "sha512": "0a6c606068843c22e17cb9e93e9d4ca119a27f01083a08dc1d7c4e063bfb998f7a73e79649cb0e3fd735d766722dd5878b41711e323ee2e561298a7f81c75199",
+        "dest-filename": "ignore-5.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6467,23 +5711,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656",
-        "sha512": "6aa5e118fefffc6ba2dbe52b12dbf16714aab905574e967b283c5f09c280177572b2fc34095895696f516758f5c65218a9a69a8a9068a9da9e89b91cd7c3cdbc",
-        "dest-filename": "immer-8.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9",
-        "sha1": "aa6cf36e722761285cb371ec6519f53e2435b0a9",
-        "dest-filename": "import-cwd-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546",
-        "sha1": "d81355c15612d386c61f9ddd3922d4304822a546",
-        "dest-filename": "import-fresh-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20",
+        "sha512": "964ed436649b02e901e41e9d87d7e78790f46c94ce14ac558367322564d8ad645f84bacb301aae38d714b37685ab9d3b84da086440c387c95bf14b4e8b348c84",
+        "dest-filename": "immer-9.0.12.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6495,13 +5725,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1",
-        "sha1": "335db7f2a7affd53aaa471d4b8021dee36b7f3b1",
-        "dest-filename": "import-from-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43",
         "sha1": "05698e3d45c88e8d7e9d92cb0584e77f096f3e43",
         "dest-filename": "import-lazy-2.1.0.tgz",
@@ -6509,16 +5732,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d",
-        "sha512": "6fab34e26dcefacdc21926ea0c8c8fe11e9a03001e62556af7e59459ea7a8876bc11345ff727a2d54e3c0b93267c9995f4088b61804a3ccabf5befd646942609",
-        "dest-filename": "import-local-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6",
-        "sha512": "be32f7fb0d28ba50156748411e7c5afcd9b94c0bab7fd60b4090e1a91672a9bf95286381e8b53cb7d1f536be42228d7abe1f577c94cea07c14d01ef54b9e7b80",
-        "dest-filename": "import-local-3.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/import-local/-/import-local-3.1.0.tgz#b4479df8a5fd44f6cdce24070675676063c95cb4",
+        "sha512": "012074eee2ed9c3b35a3a1078caa57df804a6034aa9c57ab7d33892f61ef32a17bd0b9f1a639330c1f09e38a13f69bb800c3e44307fc8e5eacce0bcd776b5122",
+        "dest-filename": "import-local-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6537,30 +5753,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607",
-        "sha1": "f30f716c8e2bd346c7b67d3df3915566a7c05607",
-        "dest-filename": "indexes-of-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467",
-        "sha512": "202963f97cfde3e77b8ab1f9a91c9f2689ce75f4f3b836a27c4e993d67f1d0dd3efc04d909bb933eada9ac5979dbabab91077dd16c942888750df050da1333f4",
-        "dest-filename": "infer-owner-1.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
         "sha1": "49bd6331d7d02d0c09bc910a1075ba8165b56df9",
         "dest-filename": "inflight-1.0.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1",
-        "sha1": "b17d08d326b4423e568eff719f91b0b1cbdf69f1",
-        "dest-filename": "inherits-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6607,16 +5802,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-6.0.0.tgz#f73d5dbf2855733d6b153a4d24b7b47a73e9770b",
-        "sha512": "5d31ef4544b86493730b51a2c494663a55924b8e5f4adf83268c900bdcad8f45b141f720a1f42d0edc8a298c4752a12c582b3e2c859fb4f17589eefe8b4d7616",
-        "dest-filename": "inline-style-prefixer-6.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907",
-        "sha512": "4b5cc1a350facdcb32b82e8f326639fb9e583082d0f5abfc968b4cc78e3b06ae92020a3fb032bacbab942a6b98856ede69c9c88457ec3e608d61d0f3b279c30a",
-        "dest-filename": "internal-ip-4.3.0.tgz",
+        "url": "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz#c5c0e43ba8831707afc5f5bbfd97edf45c1fa7ae",
+        "sha512": "02ca9acd9f0a711cc9f583cdd70307d9a34cee591643cb523eb5b9b83935ce26308803d64999d4b02ee57d9abe043a8bab3d01e0f868e70b1c59c27356f4730d",
+        "dest-filename": "inline-style-prefixer-6.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6635,20 +5823,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
-        "sha1": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
-        "dest-filename": "invert-kv-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9",
-        "sha1": "fa78bf5d2e6913c911ce9f819ee5146bb6d844e9",
-        "dest-filename": "ip-regex-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a",
         "sha1": "bdded70114290828c0a039e72ef25f5aaec4354a",
         "dest-filename": "ip-1.1.5.tgz",
@@ -6663,16 +5837,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6",
-        "sha1": "50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6",
-        "dest-filename": "is-absolute-url-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0",
+        "sha512": "d6a4e01fd346f88209e327cab367ba3e9d5b660f306c36ca1d3db51eb2c879805344b80c60a9cc4cf02e2372dcb3ad677f1e61d719579db26d1f5917e7f77f9e",
+        "dest-filename": "ipaddr.js-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698",
-        "sha512": "a2998d217eee1674bde8db4f9a1590810c7afcd60582c51760c96571fcf058a50cc1fa3c924bb54ef13a86435c1fe435b6ce5c315aec63b8f46f15d00dc8aef5",
-        "dest-filename": "is-absolute-url-3.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-3.3.0.tgz#67d0715d4361a60d9fd9ee80af3881c631a31ee2",
+        "sha512": "31504b2944da9e033711f44f1513a19964102910ecae023cdc9f064b78d7cbe3b062a891dbf6a85a7758439e35ea32c4dee68680b1fb9dc99edd7f72d3d819de",
+        "dest-filename": "irregular-plurals-3.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6680,20 +5854,6 @@
         "url": "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576",
         "sha512": "74e5a8a9f96f73274045adfad06befd7c0d9fe046e1ca8b6354ff05395f5645cdd61f1f6f67922359b05de6a78389dc7e32a3d331f00fee006373a733cddf204",
         "dest-filename": "is-absolute-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
-        "sha1": "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
-        "dest-filename": "is-accessor-descriptor-0.1.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656",
-        "sha512": "9b98671d391c56c3dfab1dc02a5cadb483dbec9f97ca41ef24fd81f5b6438e584b22812ae17a0aeb8560edba199555982ba2d463de1d60f104ecb87466464a71",
-        "dest-filename": "is-accessor-descriptor-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6712,9 +5872,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9",
-        "sha512": "d488f894e30f97fc41e640439fb23e6f6b6d3cc29af2cce1108ad70ee5d00ffa1edc724b4cb86a8601aca7083219de8c3b2c0152a56f622705ef69648039c81e",
-        "dest-filename": "is-arguments-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b",
+        "sha512": "f10ec40118f31272a9b7f3c20fb7b5720512d1ae97f2ee6d75288ca978688ce76857d4ec32c88efbd54b0b9bc098ef0deff1a65e7ef28d1f2a9c0e9b5401337c",
+        "dest-filename": "is-arguments-1.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6733,16 +5893,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.1.tgz#6923051dfcbc764278540b9ce0e6b3213aa5ebc2",
-        "sha512": "27410b178c871711f2d1c992c59ba17833b3da5b8e755bea8f0984723f07fcbd491deb840d20db7913fe0e4f641559394531736ee709d8a6fd17b8b163641a0a",
-        "dest-filename": "is-bigint-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898",
-        "sha1": "75f16642b480f187a711c814161fd3a4a7655898",
-        "dest-filename": "is-binary-path-1.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3",
+        "sha512": "cc1f42aee31a9a3ca6f358b6259dd4327e783ca1ac433b097a8eb1bcddc7249e0202c40d07a891bada764e8efb39f08dba8c6ca6c221cda3e83b5cf20848453a",
+        "dest-filename": "is-bigint-1.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6754,9 +5907,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0",
-        "sha512": "6bb529af1f14b43f8759dc98c270f5f84c6d4e0a90b43da4ff5c8982d5cfeb09cc9bc6f2864a1365197ef792cb4e1a73359279684be2e3a71d1fe6b230547098",
-        "dest-filename": "is-boolean-object-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719",
+        "sha512": "80361a2872669e3e1a5b1ca3e981f25d5a5d41ac2d54b1d4e5c6fe7b3b4f19ccdfe9c8ee4ddc2f7b964811f817a87e1ee7b027d43d4029ff02677918ad046a60",
+        "dest-filename": "is-boolean-object-1.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6768,9 +5921,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e",
-        "sha512": "2750dc31ef14613052aca7b3b885135308d7b21a36f7af77ba75ccd98849513476b712bf786e3b6ef35aff08a93c5999160aff37a7f5180eba76fd261324c8c9",
-        "dest-filename": "is-callable-1.2.3.tgz",
+        "url": "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945",
+        "sha512": "9ecbb0b7165f317ebb3abca5f4b090faea670b4674060a709eda52f3d9b51ff4cb174ccd7f37cb315ffd59affa319b23d1a72912300ed0a175c53e9974b97de7",
+        "dest-filename": "is-callable-1.2.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6782,44 +5935,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994",
-        "sha512": "9035f2b6db8b7ac94a00760bfcadbc176624337c798ef14f130df25db469b57c9d8c3f6ba4b133f82e4ae62bad63d66252ee803f8d4976f450c05e08aace1909",
-        "dest-filename": "is-ci-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867",
+        "sha512": "658bc282b79fc2aa10eb24f26146d0bbae07b084d9dcd7ca5f597368461d9130dc7cacf3088ff0b6145160a91d8c72855603625ca00a9bae59a35a64d9ab3f41",
+        "dest-filename": "is-ci-3.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345",
-        "sha1": "cfff471aee4dd5c9e158598fbe12967b5cdad345",
-        "dest-filename": "is-color-stop-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211",
+        "sha512": "49d34252cdbce21af8d2115314fea5d087d9fd14ab317177aa0a111dddffefdba7513beb14efc9a17c241a6fb927f39edc4fdbe46b271b7df4b94360469bb53c",
+        "dest-filename": "is-core-module-2.8.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a",
-        "sha512": "5d101f01dcb263917970e5e7ee16100ea8765e68a2f8311f21c406c4afee37030784890f58ed20f26b1771bccb7be3291a847de75325a8cff6888954e2f28375",
-        "dest-filename": "is-core-module-2.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56",
-        "sha1": "0b5ee648388e2c860282e793f1856fec3f301b56",
-        "dest-filename": "is-data-descriptor-0.1.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7",
-        "sha512": "8db457cb5166b40a028d0915988558c2ebaa0c551b68e7838e679dd6d3863ebb0c86d240e2b0fdb64800d05d6a2778111515dc1d856475e68fe74439ac4fe32d",
-        "dest-filename": "is-data-descriptor-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e",
-        "sha512": "5129434f9db8c28434f1aa19173877fd9e9c87d63f1165c41d0fc06913744a42aae2dd89c36476df7f6d4979b0b95a18ecb2e50426ce225c769b23ff2f9ce4d2",
-        "dest-filename": "is-date-object-1.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f",
+        "sha512": "f5841a4b1b00892c1cbd2df7301937c130959d62be1e117c5594768d1c5e84cd7a41c54e747a8f9f854f1e644ae254abdfc9fd26b8aeac89cb70ff74c6c60d7d",
+        "dest-filename": "is-date-object-1.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6831,44 +5963,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca",
-        "sha512": "6af0d8af4481dc3c0ef73b0ca2fd20282112158a829c4e21abfe33dd375496e904cb9b7d0b4611abb1cbaec379d8d01ca9729a7a97820f49fe0746ab9d51b71e",
-        "dest-filename": "is-descriptor-0.1.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec",
-        "sha512": "d9e8ace56a90195ee97a8a03c8b98d10f52ba6cf7e4975f973da4bdf1101fb87bd1e71ae0daee607b907c47c3809ba92f64d53da1387de688bf27f16b62615b6",
-        "dest-filename": "is-descriptor-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1",
-        "sha1": "61339b6f2475fc772fd9c9d83f5c8575dc154ae1",
-        "dest-filename": "is-directory-0.3.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156",
-        "sha512": "64ea2a8977c4c2d1a49d38ae0c4cbca4dd827c4dd3c4c1e9aef35eaf59978aac24393efb470dd856b510e7612a00e53740058343e6d0771ec7273aefecb4b61f",
-        "dest-filename": "is-docker-2.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89",
-        "sha1": "62b110e289a471418e3ec36a617d472e301dfc89",
-        "dest-filename": "is-extendable-0.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4",
-        "sha512": "6ab9d73314f5861a0aa3d9352d976694dc897430dfcb6bf47d78c5966a24e3e8bcba5ffa5a56d581ef5b84cef83a934f40f306513a03b73f8a5dad4f9de27138",
-        "dest-filename": "is-extendable-1.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa",
+        "sha512": "17e8b604ab05ac7eba89a505734c280fcb0bcbc81eb64c13c2d3818efb39e82c780a024378a41ea9fcfcc0062249bf093a9ad68471f9a7becf6e6602bef52e5d",
+        "dest-filename": "is-docker-2.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6883,13 +5980,6 @@
         "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb",
         "sha1": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
         "dest-filename": "is-fullwidth-code-point-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f",
-        "sha1": "a3b30a5c4f199183167aaab93beefae3ddfb654f",
-        "dest-filename": "is-fullwidth-code-point-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6915,9 +6005,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc",
-        "sha512": "e46d2d2ad05314898ea839cb076846e81a76a9c28415dba8e2d66ef4c4ff1fa350bff821872df4a39e6e7da7f127f2dd1fbf4b2ecd8a7eb9fce532cac80ec152",
-        "dest-filename": "is-glob-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084",
+        "sha512": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
+        "dest-filename": "is-glob-4.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6950,9 +6040,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24",
-        "sha512": "db3e89cd0bd945af40d98ef10ba750426e054934933568ca218613b78db8e9e313266228d10f99c8eb14eba5fc9712b501b07dd9d15e8253cbae1c2979128eeb",
-        "dest-filename": "is-negative-zero-2.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150",
+        "sha512": "76a26f6ab2dac17b056cd0de256ef3033f08b49f5c776f18b9fbae1738741bca4d1e324c9d8d3c0efeec617dae17952940ec2278078e13111801659fbbb65950",
+        "dest-filename": "is-negative-zero-2.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -6964,16 +6054,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197",
-        "sha512": "ce88707a5380babfb9b97b64f0edc63d0d5e01cbb8657dd4c314215257c514c36951df378178236e1261e87981e8b50d57f89e38b42e0f024eddd589a2c51e33",
-        "dest-filename": "is-number-object-1.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195",
-        "sha1": "24fd6201a4782cf50561c810276afc7d12d71195",
-        "dest-filename": "is-number-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0",
+        "sha512": "6c454eaa245cbe8df33b5f86da554ccbe8249049bd621edc0cc46eb0a2aee5924a3d46122702024ca66b34a1c0d846d23f44eed3ee81fde9ac60d1d9ca7e8af2",
+        "dest-filename": "is-number-object-1.0.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7006,20 +6089,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz#bfe2dca26c69f397265a4009963602935a053acb",
-        "sha512": "acda1c5c7822a4efabbe73fa764df3236d11a4eb6b00cfe4cdb076e7c530e415abdd3a578bceb5cb38e8d7a0e7e21528c74ee2c3903278c2c75acba3923cef45",
-        "dest-filename": "is-path-in-cwd-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2",
-        "sha512": "c22ca14f37c35acbf0016e77381585e73baf68e1a567a3f063101b3d50e1a66fa0334f712901a306affcb98375d9a0ef3319c09eadddc53ca84a844d9a0e5816",
-        "dest-filename": "is-path-inside-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283",
         "sha512": "15de200016fec9c18098aa2ef1e31fb42ba94a2af9951c6a7f8683fef774703daa7381cbd3b3a309eb8732bf11a380a831a782283074fc40813955a34f052f3d",
         "dest-filename": "is-path-inside-3.0.3.tgz",
@@ -7034,6 +6103,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7",
+        "sha512": "830b0e136f24fb6dc63f507abc5975a1587f58ece66b006b2b0a3912feb030accf91a5da0832102b32e7bec038d834656d54d6a2b9204ca22f8802825a47d4c0",
+        "dest-filename": "is-plain-obj-3.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677",
         "sha512": "8793e98179168ad737f0104c61ac1360c5891c564956706ab85139ef11698c1f29245885ea067e6d4f96c88ff2a9788547999d2ec81835a3def2e6a8e94bfd3a",
         "dest-filename": "is-plain-object-2.0.4.tgz",
@@ -7041,16 +6117,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397",
-        "sha1": "0c52e54bcca391bb2c494b21e8626d7336c6e397",
-        "dest-filename": "is-potential-custom-element-name-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5",
+        "sha512": "6c261e440dab5626ca65dfacdbadb98069c617fb7b0d2a83b3874fec2acb0359bb8ca5b3ea9a6cd0ba582c937c43ae07b663ca27586b3779f33cd28510a39489",
+        "dest-filename": "is-potential-custom-element-name-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251",
-        "sha512": "6b1bdd85be697611154e1a89cd85f032556e6700be145d83a5c3a14d2fb2ffc8d5ab8b6bc723e07dcc08c482a2c9eb8b9524182a499468f409f19138c8d2970e",
-        "dest-filename": "is-regex-1.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958",
+        "sha512": "92f45dc43b31663873517d3b6672f27734b54d4fd32654d41c763860b2fcededfba14038f437e42ea832f958c5a1ca30cb6f5c2af7128aefa422fef6f234d356",
+        "dest-filename": "is-regex-1.1.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7069,16 +6145,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88",
-        "sha512": "aa00d85c5491e56bc47ee4b974c8faa133046ebad268cd02ac5936622abf8179c1bc3f6931ada3197c728462dfbe1669b8c65ed7c089a45c40b77091b38d8d32",
-        "dest-filename": "is-resolvable-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c",
+        "sha512": "0063ab88da7deaf3417771ed53e47314473be457d1e729a262ff04e79dc8ef548279706232c54352d762a3538416facfc8b210f6d551e51c572057b93d416332",
+        "dest-filename": "is-root-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c",
-        "sha512": "0063ab88da7deaf3417771ed53e47314473be457d1e729a262ff04e79dc8ef548279706232c54352d762a3538416facfc8b210f6d551e51c572057b93d416332",
-        "dest-filename": "is-root-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6",
+        "sha512": "214d0d9b2927619374ac285c2a144ed57f0b633e48b23fc5b2a87c3493927fe37f842393c32dbd177d8893b6be42ccc4eb721dbe6c1d4cf0dde9c679a60e1cc0",
+        "dest-filename": "is-shared-array-buffer-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7090,30 +6166,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3",
-        "sha512": "5c2a32f96954afb775f99f06812b979a9b94142f5f3a145782524cc7e7702ca4e42f8e028dde16d59e4ff81419a6bf9c47ddda18fe12fecec5b70e8d77f92213",
-        "dest-filename": "is-stream-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077",
+        "sha512": "845a222624e5eb79e7fa4b2d1c606d7b05922a740ba726f5e7928785e035977f6ebed3bd9d6228a75a77b9da8f71477fc5b17554b30ee27ece23aa7b45b9e00e",
+        "dest-filename": "is-stream-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6",
-        "sha512": "6ee63a54d463850322175a960e8ba5a199506d18433c279bc314a3c4c8f181e9984f8e9831dd8d474fc7f9f06111f597e00ff0f53049fa897ea24a8928513abd",
-        "dest-filename": "is-string-1.0.5.tgz",
+        "url": "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd",
+        "sha512": "b44d945f38af8deea87cf5bb976ddc8c338c6b4f606fbc6502a1ba8c6e5e8fab8f577d939563f734a3e282d68678736ef5fa2171c458bc889931f38e9ce614b6",
+        "dest-filename": "is-string-1.0.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75",
-        "sha512": "822e221cae772d1dae8e12d5563fb7ed8921f462ea6075fa24e5576cb02e71a1bf0aac3dc707453a30ccdaa7a27cbb35b05d67a575c5bc3bb4af91cd80232bcd",
-        "dest-filename": "is-svg-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937",
-        "sha512": "3b08a385a45282abe19bfd19740717359b7d95874a1697110d3e542d4b985cfa13efde1434e754fa0a53e91ce8edbe15d87525fe8a7a1aa63cf78019c2ff5f69",
-        "dest-filename": "is-symbol-1.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c",
+        "sha512": "0bf08f06a2969ef75cc6a200471c8e878bf551410e087a600dad16620a4a0c532ccdcacf71f7e0e6e8704a03c22c3d965b19aaea2b22b33f3bb734f4d6db8686",
+        "dest-filename": "is-symbol-1.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7132,6 +6201,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7",
+        "sha512": "927c46daae140b7bbcb2d446c8054908e771166bf90d989171d94868041701b49f2726be3a1a29368b4b42bb2d061aaeaaee19a6e29b0dcffc4ba9a05e03c53f",
+        "dest-filename": "is-unicode-supported-0.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72",
         "sha1": "4b0da1442104d1b336340e80797e865cf39f7d72",
         "dest-filename": "is-utf8-0.2.1.tgz",
@@ -7146,16 +6222,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d",
-        "sha512": "7972b55089ead9b3e68f25fa7b754723330ba1b73827de22e005a7f87a6adce5392a4ad10bde8e01c4773d127fa46bba9bc4d19c11cff5d917415b13fc239520",
-        "dest-filename": "is-windows-1.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2",
+        "sha512": "a9cb6cb8b666210d3ebd248c7e856fc857b6f86484be7999d9ecd3ba9d5206c7bdfadc0209e89a97a1048b735cd8a15c7fafaacf61413e78d7b24f3184a49a3d",
+        "dest-filename": "is-weakref-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d",
-        "sha1": "1f16e4aa22b04d1336b66188a66af3c600c3a66d",
-        "dest-filename": "is-wsl-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d",
+        "sha512": "7972b55089ead9b3e68f25fa7b754723330ba1b73827de22e005a7f87a6adce5392a4ad10bde8e01c4773d127fa46bba9bc4d19c11cff5d917415b13fc239520",
+        "dest-filename": "is-windows-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7202,13 +6278,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89",
-        "sha1": "f065561096a3f1da2ef46272f815c840d87e0c89",
-        "dest-filename": "isobject-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
         "sha1": "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
         "dest-filename": "isobject-3.0.1.tgz",
@@ -7223,23 +6292,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a",
-        "sha1": "47e63f7af55afa6f92e1500e690eb8b8529c099a",
-        "dest-filename": "isstream-0.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3",
+        "sha512": "78e789e411c298762f40aef1b7d1a4747bb3b82192d58ea0f46be7c77626df77f3fc7a4b458c624b4c0736bfa6fcc042f01eb8ed7b7ad3cbc20c4be197d73a33",
+        "dest-filename": "istanbul-lib-coverage-3.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec",
-        "sha512": "522508ab1320443113e9e47ea391db7d160fd65d21aa458eb3bbcdc42fe6820bad08c508856326f200076fcb479727c3dff97aae580d03970a743cc401fea112",
-        "dest-filename": "istanbul-lib-coverage-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d",
-        "sha512": "05781097d91fe164c23c20a99851a8264cfffae86f9bb87b3c529463187ba9aad0777111df7bc71bffea684f1e376e65d3b62a64fa475d4f48d3d97f443e5a19",
-        "dest-filename": "istanbul-lib-instrument-4.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz#7b49198b657b27a730b8e9cb601f1e1bff24c59a",
+        "sha512": "733c14cf9db9ae43850c9c5f28aea661f22cf7304a20bcab650c63cf700186341785b845b126e8d475bf04572c0e77c9609580ead851479fd3518daab395bdf5",
+        "dest-filename": "istanbul-lib-instrument-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7251,16 +6313,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz#75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9",
-        "sha512": "735e8ba4546447cbd05f21d9e672e9637e4966dce3d4f418d626667ac51b7f51591db22ea5c59f8e0397058f581e42c443aa6ecf5bb80e08faaa653f0e2b2b66",
-        "dest-filename": "istanbul-lib-source-maps-4.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz#895f3a709fcfba34c6de5a42939022f3e4358551",
+        "sha512": "9f7b3c13091d1482421b704f28162fb248171a8cbcf00473bde8248ad93ad0dc5177096d2ce4da1fb09488c457bf0628ae5d10ef5da212371607e7cafccad657",
+        "dest-filename": "istanbul-lib-source-maps-4.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b",
-        "sha512": "f6d66fcfb0224773c40cd1a257dbc8a2e43f10072a31716691c035083153c0e07df0e6550cbd0f1fd8251e8b5fe54829e8608e4f2a5fcc6588fceaa358d09153",
-        "dest-filename": "istanbul-reports-3.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.3.tgz#4bcae3103b94518117930d51283690960b50d3c2",
+        "sha512": "c7d2ed0d5b5f9bfb7518588b97735f7c2ee1cfe235ada82f817d4ffcb83536521a8227d90ca524bae680c47feaa708f622e11f0fc1b606cfd42a9fac67fa4a92",
+        "dest-filename": "istanbul-reports-3.1.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7272,30 +6334,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0",
-        "sha512": "7c34bbb332dc63db02b488a9f058ebcbda067f723686dfd04f6d5b0079b90e67f4983e17dd178d51fd7bcbe6cee9f47c5a06c865395bc86d5a93fe7771b47329",
-        "dest-filename": "jest-changed-files-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.4.2.tgz#da2547ea47c6e6a5f6ed336151bd2075736eb4a5",
+        "sha512": "ffdc7c3237a4bb3510a0f8c31db0625db34405aba1acf53672dee6f137c283af72c2dd72fcdfb26301a1de00a99ea512de495858353f952360bfe261a03da4d4",
+        "dest-filename": "jest-changed-files-27.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-circus/-/jest-circus-26.6.0.tgz#7d9647b2e7f921181869faae1f90a2629fd70705",
-        "sha512": "2f6fd8f6cccde8524f5852bc933597c1fa7e14e47bc6ad1c50be2522c75b21dc33dd587a3f59eba5ca8e95e4b3af6f333ad48740d57d67b4e5f8a92e2bbb7936",
-        "dest-filename": "jest-circus-26.6.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.4.6.tgz#d3af34c0eb742a967b1919fbb351430727bcea6c",
+        "sha512": "500ec02391d9ad6e3044cef6468f34b91476160fbb9d1d061126d223fd8cf9a99b6f356e03ade69f94f5a7767fc25867b731a9206d71c7bf063f660891fe8f85",
+        "dest-filename": "jest-circus-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.6.3.tgz#43117cfef24bc4cd691a174a8796a532e135e92a",
-        "sha512": "185f67a0149af6dd3ca52ca5dc26387eb32baa9f9a4171461647f98443db87fa4850561630ae992d37db99a771255709add4680a195642c03656425c0c52bc86",
-        "dest-filename": "jest-cli-26.6.3.tgz",
+        "url": "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.4.7.tgz#d00e759e55d77b3bcfea0715f527c394ca314e5a",
+        "sha512": "cd111886f8e3a9ed4ab06575e66767c634e128d0e0cdad5f8434fe894b1758b0aadecc5ef70e719efc9cb5c6154f93dc74b4a3bfb639742c134b7142175b62bb",
+        "dest-filename": "jest-cli-27.4.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-config/-/jest-config-26.6.3.tgz#64f41444eef9eb03dc51d5c53b75c8c71f645349",
-        "sha512": "b79a9d223fdb0a3da3ecd1551dbda7141e1a51d7ee7039f72512a0ad99e995bf2789e022ac0cd14873fcb8311dfaa57aca0ce0f4fcf8606ed44c97fde0b3d2ca",
-        "dest-filename": "jest-config-26.6.3.tgz",
+        "url": "https://registry.yarnpkg.com/jest-config/-/jest-config-27.4.7.tgz#4f084b2acbd172c8b43aa4cdffe75d89378d3972",
+        "sha512": "c73fe8fca24911e74732b218f6fd8f6ab228612ad2558e8855e138cf96778b5d351a80395e07db273fb50bc1183ecbfbbbb7f7f5d4bc17dbf8e811c3867d2f97",
+        "dest-filename": "jest-config-27.4.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7307,30 +6369,37 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5",
-        "sha512": "443678233dd06ed456c9c77c6d410fc50b139586b37d89ff87947ae4573a80e7f0a33161a089b1f9a7dfce4cbf14506ea8848f4ea8d7a26a0818954a056a28d3",
-        "dest-filename": "jest-docblock-26.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.6.tgz#93815774d2012a2cbb6cf23f84d48c7a2618f98d",
+        "sha512": "ce3681d2c8742dbd775723ec77dd95ec792a17ac8a447f6f9b7debc01b7bacf62ba50bd2d670af948cb6a4809b2ad6be6635a78182cd9f87022b89f26648d2ff",
+        "dest-filename": "jest-diff-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-each/-/jest-each-26.6.2.tgz#02526438a77a67401c8a6382dfe5999952c167cb",
-        "sha512": "31eaff7f429a0136e397c30227ed0612935daa69d598362a0932584efa28eebaa64620e5966a7601837ed3a17dde75dc637babf528488d2f823bfb83f816c7e0",
-        "dest-filename": "jest-each-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.4.0.tgz#06c78035ca93cbbb84faf8fce64deae79a59f69f",
+        "sha512": "ed305acd474228657bb2f67e821ec2f1eb009f0789a06f92bdc17a0a3aa3e25d7bcc0daad5c330c7624e6d28a8b9b937d7b1fe72370780ffbb7d3b3ad296ae96",
+        "dest-filename": "jest-docblock-27.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz#78d09fe9cf019a357009b9b7e1f101d23bd1da3e",
-        "sha512": "8e03ea0abb9396ddcac2a839fd6545c8720e247b2202f85ca76aa2476410b2db86f725a8c79fa21e953766b701c56d784f87dee59ebc8c07cb461ee3a0248fd9",
-        "dest-filename": "jest-environment-jsdom-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-each/-/jest-each-27.4.6.tgz#e7e8561be61d8cc6dbf04296688747ab186c40ff",
+        "sha512": "9fa403abccb61ec9a7db6b51920024fb3e8c097ecc795940cf19990ec85f4b68cb71a065ca1a45ded65224b47e9179a1db7184bd2d288cc47c8ba65e46fa5070",
+        "dest-filename": "jest-each-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-26.6.2.tgz#824e4c7fb4944646356f11ac75b229b0035f2b0c",
-        "sha512": "ce1b4c8a8dc4c6dcb5f1dcbc79ef1e27d9239d1c990b53780b536dfd54a13756a9c9773cad61ad27d948eefaa259ccb25d2e01552127f65c403360fed3bfd36a",
-        "dest-filename": "jest-environment-node-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.4.6.tgz#c23a394eb445b33621dfae9c09e4c8021dea7b36",
+        "sha512": "a37771e69fe41cf6d4951bd2363ca911c12d82ce8b9af11233381115013a73e3ebc25d892c0e1167ba809f173954cf24badb06453075e635de7926c9b0a37d88",
+        "dest-filename": "jest-environment-jsdom-27.4.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.4.6.tgz#ee8cd4ef458a0ef09d087c8cd52ca5856df90242",
+        "sha512": "c9f1e567d9be9334ca655d2155f855bba1ae0f128061e147adfba59b2ec9c70b2ae15efe64aedff9cd173ffb5b5433105bb1389de1b6bb5e3b84592e573d0c95",
+        "dest-filename": "jest-environment-node-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7342,44 +6411,51 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-26.6.2.tgz#dd7e60fe7dc0e9f911a23d79c5ff7fb5c2cafeaa",
-        "sha512": "79ab162095c8c3bd41d91751f2482aa6342b6cc4564018220705d8121b46513697f9da028c185e96e4a174331e47c20c7c9893a87e3ecdf86d836f5aa497fff3",
-        "dest-filename": "jest-haste-map-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5",
+        "sha512": "b64f68fa57794d6ab8d4390ad782f8c28c78b360fd32d4e929a015cd77ebe4250a9b964ad84c5c685134aa5b365bbd7313fe91d93c71acaf70dabeacbc014305",
+        "dest-filename": "jest-get-type-27.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz#adc3cf915deacb5212c93b9f3547cd12958f2edd",
-        "sha512": "90f294ad0b5cf1a630055ec2a81839a6efad9985e5bc59521589f5f1ebf880f16dad1cc1d79376816fd1a1ec37d7ceeadb0d9e1eebb4314f53273eb0d3f9cf12",
-        "dest-filename": "jest-jasmine2-26.6.3.tgz",
+        "url": "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.4.6.tgz#c60b5233a34ca0520f325b7e2cc0a0140ad0862a",
+        "sha512": "d2d36983183b04abab65e16420ebc60a46e63876cb15fe0b5103b1ad048c8efad06907b797a13cc7a8d80b536e5a41a8e560dd6ebf05133531576f8b58d6b029",
+        "dest-filename": "jest-haste-map-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz#7717cf118b92238f2eba65054c8a0c9c653a91af",
-        "sha512": "8b8c655e9b1548c78abe0d9c10a75f861d07dfdaa52653f9131d72431c05f6e6da85ba1060c813b73e6830bdf901503707812ef98b26c1a88a55ebfd282bcbc6",
-        "dest-filename": "jest-leak-detector-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.4.6.tgz#109e8bc036cb455950ae28a018f983f2abe50127",
+        "sha512": "b8018d5c5eb8e08ff087386c7fbfea7fbe20ab2f4eba1bc9d17629f120de717da8a0679a3e79893235e32add26aa1d5197976d446c4980dac794140805f4b937",
+        "dest-filename": "jest-jasmine2-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a",
-        "sha512": "9659dcf2f42061c36a0eba910d75b032bf62eeb4b95c5882c2f87a0d33fb26a6b69aaa5c081065a426e7fadae41b428d84fbbf87caf3c8192b88eb41b2dbd687",
-        "dest-filename": "jest-matcher-utils-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.4.6.tgz#ed9bc3ce514b4c582637088d9faf58a33bd59bf4",
+        "sha512": "9246868b10dff51ec28c79b6a4ecdf4f16534104368074c858a63f2594a261373dd1b669f244999d4312dee2c07f04d9c1cd2d70c468117ef87b5e0b1b559aa4",
+        "dest-filename": "jest-leak-detector-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.6.2.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07",
-        "sha512": "ac688b78fcd0dc0cf052c86edbe467f94305934a47379f2c386f886896e4e49c6eaa8dcd60ed54dbf3084784b5b0a82ca184974b376d49ad1382b9ad53011b98",
-        "dest-filename": "jest-message-util-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.4.6.tgz#53ca7f7b58170638590e946f5363b988775509b8",
+        "sha512": "5c3e0f293dd69f52d09d102aed9b13234551b8473d3ab08f1623b55cbedb7ed4c699f345d03704c0c1d182a8aeecd19ff19a190d11291ab0a7883923b7bf566c",
+        "dest-filename": "jest-matcher-utils-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302",
-        "sha512": "63216378f1c7a752f3a7361c9a0aa42749e6d2083f949c76699173172d52e9e52a3635ec3aa4cad74ccd45f7f674d7ecb20a248e41bae4e95635c22581ddf37b",
-        "dest-filename": "jest-mock-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.4.6.tgz#9fdde41a33820ded3127465e1a5896061524da31",
+        "sha512": "d29e6cceb88553453be1ccd14858c7e91c92ed46080249ff9edc0cb8ec13196ad020e8793735d7aeaef62cea8890928abc56cfabe6f264ab81cfbf1f8c111104",
+        "dest-filename": "jest-message-util-27.4.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.4.6.tgz#77d1ba87fbd33ccb8ef1f061697e7341b7635195",
+        "sha512": "92fa23758464b2df22552675109faf7354510fd965b9e0632b35f3782cad1f774c33bcef3d5fd42dc7c8da7af4bf4554826dc18edde104242f39e681cfe6531f",
+        "dest-filename": "jest-mock-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7391,93 +6467,79 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28",
-        "sha512": "1afdd922cfe7038f3f66f8eb977e1b7fea03efa2478860d4c4d3958148e1de3f3dd2c6e55ebca3638aecb3bd5f3ed0ff9e372197a3d213684886fc966b5793d0",
-        "dest-filename": "jest-regex-util-26.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.4.0.tgz#e4c45b52653128843d07ad94aec34393ea14fbca",
+        "sha512": "59e0a9329367a8960c4283a39b59d3b6c81b4785c7024d6ed34a83a0d050a3290cdbcd3efd39a0039421e60882d5e732e9ae5de216d2b07ce906dbb9caf95b12",
+        "dest-filename": "jest-regex-util-27.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz#6680859ee5d22ee5dcd961fe4871f59f4c784fb6",
-        "sha512": "a55c148c99316e17b8458f10116ccddef9ecda4ab2ba574aa71971265cc461f292bd8ebf6ccbf1a05ad863350ed46c76f32296377eeac95eeb228229da1f1f4e",
-        "dest-filename": "jest-resolve-dependencies-26.6.3.tgz",
+        "url": "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.6.tgz#fc50ee56a67d2c2183063f6a500cc4042b5e2327",
+        "sha512": "5bce6e2597055c4559efe319a883c2b1c763b9cb6bb8d197519dce1d25ce7d747d21381b50a7878feb867227acfb44acbc8e46b547d3c38758eeef6a8d3bd03b",
+        "dest-filename": "jest-resolve-dependencies-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.6.0.tgz#070fe7159af87b03e50f52ea5e17ee95bbee40e1",
-        "sha512": "b51033d9bc2b687b9f369f820a6003f1c8b20a95c2b35350c41e442409ad085cba04df359681441962b362edba63ada500925ee17e23837e8a7fe36c432892b5",
-        "dest-filename": "jest-resolve-26.6.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.4.6.tgz#2ec3110655e86d5bfcfa992e404e22f96b0b5977",
+        "sha512": "4857c84d5029aad8ab6c84ca1403bb8ce54de395201737117506a7385ce39db77e080083a32797ef6d3a27253dda5e1c46bef7f90cbf4e55b9d7ee2f1c6b7ecf",
+        "dest-filename": "jest-resolve-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.6.2.tgz#a3ab1517217f469b504f1b56603c5bb541fbb507",
-        "sha512": "b0ec6c64eab6e664f5c11b1f1dc6ed9089d2f8493b43c8c21d40746544cfd2d73f738d501eb894fcdba7a8c7c2516b0be07dcc1e9bd00f8411f64498852ed4bd",
-        "dest-filename": "jest-resolve-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.4.6.tgz#1d390d276ec417e9b4d0d081783584cbc3e24773",
+        "sha512": "203785b76486e03cea6a560165181b6cf9a9c15dd7d03727b637b33c1111be78702865935bb0b9a5b6c0e655649af82d79e35f75dff6de0c2abf76a28a5a583e",
+        "dest-filename": "jest-runner-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-runner/-/jest-runner-26.6.3.tgz#2d1fed3d46e10f233fd1dbd3bfaa3fe8924be159",
-        "sha512": "6ad80aa511e7680d8ebc1c86fc7a4603883a0923d2ff52cad232b78004c9028a6d0b5a2396da66565602dd36207661a9f862ee873a47df41afb37eaccd22f625",
-        "dest-filename": "jest-runner-26.6.3.tgz",
+        "url": "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.4.6.tgz#83ae923818e3ea04463b22f3597f017bb5a1cffa",
+        "sha512": "79761ea11fcc6c8a550eb8eacb977a70608539804514378a68d5aa4e9d21e84ef874ad332c7cc04905c9a65e5adbfe347ae0662a7a6b34b2742a1d0b0a776759",
+        "dest-filename": "jest-runtime-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-26.6.3.tgz#4f64efbcfac398331b74b4b3c82d27d401b8fa2b",
-        "sha512": "96bcf247737cb1a71300c7a89dbaa99d291ad5d1cdbb1dae934aaa0d756432fd9cfc0df0627bd0e045ee234d7763afa048a482c5d69ccef7f81c5d265571d177",
-        "dest-filename": "jest-runtime-26.6.3.tgz",
+        "url": "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.4.0.tgz#34866586e1cae2388b7d12ffa2c7819edef5958a",
+        "sha512": "443869727e5fd496135f6a6f240183727b0d4e7b15f5b8d83d4f31715fb13f03979d43ce4307f8644ba253a1bd1f5533b47f8e6a9320bbf724115c0ef3b3f09d",
+        "dest-filename": "jest-serializer-27.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-26.6.2.tgz#d139aafd46957d3a448f3a6cdabe2919ba0742d1",
-        "sha512": "4b9c2acb3d035e73493ddff17c8cd9e579e9d47ac958173383c98c7cca4defc389e5e0f15f27fe62095df705f50e75166c86e133560363de4d8d1e0205791bda",
-        "dest-filename": "jest-serializer-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.4.6.tgz#e2a3b4fff8bdce3033f2373b2e525d8b6871f616",
+        "sha512": "7da7d40832d07f3b8d3fd211704a9a14033311eeeee4117b9ae75ee75c325afed545ec7ad16ce76480bb0df29381222525af1a1736265dc966377dbc6aa48399",
+        "dest-filename": "jest-snapshot-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-26.6.2.tgz#f3b0af1acb223316850bd14e1beea9837fb39c84",
-        "sha512": "38b871cf4e44cd4b6c02638cceeba9b7594761708d89bd040b2b99fcf64ec7d4eb65c0bcbcbd31f83506dd32fe18b5f7c871b8e5ee981a3226d17c03737ab7a2",
-        "dest-filename": "jest-snapshot-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-util/-/jest-util-27.4.2.tgz#ed95b05b1adfd761e2cda47e0144c6a58e05a621",
+        "sha512": "62ec71a5753a9e531a9fdab22eec4768c30ecd7025e5a1995824b36de9f90e12c77a6610c4273860afb82f766b0aeb53f063d0fae8bd9390fcad42680e2a0c9c",
+        "dest-filename": "jest-util-27.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1",
-        "sha512": "3035b47ca7ec9f4388ecc4bb12ecfa87c1cd0d7550d2068cf6e5ba4637c399dd4300571ac57f4ea886a41c8aa16e7985d3c09fd832c31beba5abc6104342e9d1",
-        "dest-filename": "jest-util-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.4.6.tgz#efc000acc4697b6cf4fa68c7f3f324c92d0c4f1f",
+        "sha512": "f3bda612608f56506a6c0e5d4e80b9eef037c8968c45f21da42a03ddcc8758938cc7e489c0b370d08ef51245ace35a336bf12bf599e8f57b939116023c35095d",
+        "dest-filename": "jest-validate-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec",
-        "sha512": "344619f407b28f48b9ad0a9babeb6920ea26d184b5bb6315bbaf9eb81b2fa602267be14e7d19a80b8479a74262014a5a16f172db8c60ae93249daad1ffddd78d",
-        "dest-filename": "jest-validate-26.6.2.tgz",
+        "url": "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-1.0.0.tgz#4de2ca1eb596acb1889752afbab84b74fcd99173",
+        "sha512": "8f1a2ccda9406f7f785849668894c504cce27bf443085f96ed0dbd9f92f338fb5ca10a0759f754b471646e181fe4dc167bcb8c3b1bca6ff83b79aec2b217e44f",
+        "dest-filename": "jest-watch-typeahead-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.6.1.tgz#45221b86bb6710b7e97baaa1640ae24a07785e63",
-        "sha512": "2135671e18f725dfd092a41c4ea65f4608dfc9184314cfdabb3815a3644abd2c22d7c60cbe1d16bd70c91681440fa73b8ddff98f1b6ee2448e6fd3d3bb670f56",
-        "dest-filename": "jest-watch-typeahead-0.6.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-26.6.2.tgz#a5b683b8f9d68dbcb1d7dae32172d2cca0592975",
-        "sha512": "58a2686f43ff126d9cb2256d86c23af29e9a18a4c872c7e31fd1acc757f403722d6a5cf8ddede1a3481e48056c9a3d3d4563842cfd4067f0d7c8980e8032b15d",
-        "dest-filename": "jest-watcher-26.6.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5",
-        "sha512": "e753c4e2168c497707a219d231d338d9a9dbbd900d613a8caebe76b5528faaab0f24cce83fa15860356a6a15ff1eb0282842b3dee50fcd2bcab3d037a91e2257",
-        "dest-filename": "jest-worker-24.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.4.6.tgz#673679ebeffdd3f94338c24f399b85efc932272d",
+        "sha512": "c8a436d0e3018820e281b0f4aae85028b9013be39b18defd30ee274fb61a0ae43948cf9d90135613c7195f416353a733c0cbd6c3a4ad59b7be5afe2324f27e7f",
+        "dest-filename": "jest-watcher-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7489,16 +6551,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jest/-/jest-26.6.0.tgz#546b25a1d8c888569dbbe93cae131748086a4a25",
-        "sha512": "8f14e6aefb9e715212bca14584e923b1645957bb05a9d49401dd5a8ce298fbf404fda2c156cb6c27f757f067332f3c224fa644c30999aad0941cb1c7415cdc7c",
-        "dest-filename": "jest-26.6.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.6.tgz#5d2d93db419566cb680752ca0792780e71b3273e",
+        "sha512": "80758917fe978b90931b9402bd13abe86726a48a8d6290c9c9cf00d61fc3c97a87d6d0fa4a74423347775399ac577d43d8b07f53e13433e5b8a32bca578e2837",
+        "dest-filename": "jest-worker-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/joi/-/joi-17.4.0.tgz#b5c2277c8519e016316e49ababd41a1908d9ef20",
-        "sha512": "1785a25b6c5a57ac1cd63c5eb5eef4470e15fd5b8c77a20df9ae62959b311b8b98b545d6bb692af56e4fd9dcf7d1eec69b0f1109b63fbbfba4f9d30f99af6d02",
-        "dest-filename": "joi-17.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/jest/-/jest-27.4.7.tgz#87f74b9026a1592f2da05b4d258e57505f28eca4",
+        "sha512": "f21798becc7b9d5fe6f26db8564dba63cee0ef705aeae79477431679dfcd5cc8526489bad94fe59556d2d0f25ed521ee9dbc978c9fc1a86d73f5b16319422f4e",
+        "dest-filename": "jest-27.4.7.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/joi/-/joi-17.5.0.tgz#7e66d0004b5045d971cf416a55fb61d33ac6e011",
+        "sha512": "47b851e7408ea7b4adccb9c38b8cb03971eb06b80d5ee5147c958847994f639066fe9383de365a4f0a65b945d52d159ca1667192b1c1049e612f182795e85b77",
+        "dest-filename": "joi-17.5.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7538,16 +6607,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513",
-        "sha1": "a5e654c2e5a2deb5f201d96cefbca80c0ef2f513",
-        "dest-filename": "jsbn-0.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/jsdom/-/jsdom-16.5.2.tgz#583fac89a0aea31dbf6237e7e4bedccd9beab472",
-        "sha512": "27136d3edf42d6eb7ce5ba026c999f7da434e8d067ce4418fcc58edd8c4f5bc2164b7f00dbacfe075a01bc0f4bc0aaf2b5ec1d7f29a7862e14347dff440819ae",
-        "dest-filename": "jsdom-16.5.2.tgz",
+        "url": "https://registry.yarnpkg.com/jsdom/-/jsdom-16.7.0.tgz#918ae71965424b197c819f8183a754e18977b710",
+        "sha512": "bbd4a67361b55124ad33eb3fc75aeee52c6b97a98f6026c1c86d54fe1526a9a56c9b8b5b3724bb0a270e491cae190619853bb487ce2a919650fc8f9dce2cd257",
+        "dest-filename": "jsdom-16.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7608,9 +6670,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13",
-        "sha1": "b480c892e59a2f05954ce727bd3f2a4e882f9e13",
-        "dest-filename": "json-schema-0.2.3.tgz",
+        "url": "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5",
+        "sha512": "7acf783379d321fb043e2b1169f6a4f870cb7c75e7281855def5397aa3dc4b77e5216a9cc495a05c75e27b2dd8ae968db1a9d8e5e8b55686046cece28eeabd04",
+        "dest-filename": "json-schema-0.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7629,13 +6691,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81",
-        "sha512": "73bffc99b52c2a28006cb903e41d35d012b80fd2d99bb035a4d22d904c2251946920deba7b1bbf7bb6105b2b06ba7f9344a689a7c3217a633e5647d6bf8d9a08",
-        "dest-filename": "json3-3.3.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe",
         "sha512": "68a4b85908cf7a7471890b02f7730d7e3c7e9db1783c0758ce677fd49223f07633a9f6eef3a6de4ee3605c3ccf9275a4d27d2e0119727b0668e2cfbe112dfa3b",
         "dest-filename": "json5-1.0.1.tgz",
@@ -7646,13 +6701,6 @@
         "url": "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3",
         "sha512": "7fef1c95dbbb5ffcbb44026eacc10999da0a5c607f5f9e74c3636bded4db7b32fa470104fe231c9beb599d77a866d2ae3aae9fb7cf82ab3124ac8831d5f3e840",
         "dest-filename": "json5-2.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8",
-        "sha1": "3736a2b428b87bbda0cc83b53fa3d633a35c2ae8",
-        "dest-filename": "jsonfile-2.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7671,16 +6719,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2",
-        "sha1": "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2",
-        "dest-filename": "jsprim-1.4.1.tgz",
+        "url": "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072",
+        "sha512": "3cd61921d323548bd58034982934fadd8f8a67a219bc644d356731c03f86367533d4c28f7efdf427cb9e0a377070dd270f1d9296c860c81ececb47a903355146",
+        "dest-filename": "jsonpointer-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz#41108d2cec408c3453c1bbe8a4aae9e1e2bd8f82",
-        "sha512": "108b26b773b7963b14eaca2dfc9e04d730d1c5f04dae18f27ff38a8e5c9dc20122990bb39e53385afed4fae78e349332127d56444d0af1d862ddd5405d84f6e1",
-        "dest-filename": "jsx-ast-utils-3.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz#720b97bfe7d901b927d87c3773637ae8ea48781b",
+        "sha512": "b8fe6fbbcc5fcb617d03a2c60b6d8a3bb7b6fef1934b53213fed7c7fef993657f43a16b16dcf67204c0702c7a39492b2cdf67353950885ee48b58922b5c66764",
+        "dest-filename": "jsx-ast-utils-3.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7692,44 +6740,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b",
-        "sha1": "79d93d2d33363d6fdd2970b335d9141ad591d79b",
-        "dest-filename": "kew-0.7.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9",
         "sha512": "f72909ff8e9237ff4a3ccfec89c87343b3af5f218360a19368394a306080960d942bc291cb88dbd1df2c15cfb44edd186274e1abc5f645980283be113f181c54",
         "dest-filename": "keyv-3.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892",
-        "sha512": "2f3aad2ca954c22ac453297f9e2722ad598d88fbd8b3b9799fcc0e3cfedfc8956950f92f0a75bfbee8971a9ca51949673c39c1ef7d75ac047302ddcc86cc298e",
-        "dest-filename": "killable-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64",
-        "sha1": "31ea21a734bab9bbb0f32466d893aea51e4a3c64",
-        "dest-filename": "kind-of-3.2.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57",
-        "sha1": "20813df3d712928b207378691a45066fae72dd57",
-        "dest-filename": "kind-of-4.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d",
-        "sha512": "346104ae71fa176bd4b970e1f8e95b70a5bbff039c7dd447699ed55ada82ced7c7ae2ffef982a63f9d4e7567863eea8239b6ba924d8e4dee5dd365664c1f343f",
-        "dest-filename": "kind-of-5.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7748,13 +6761,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439",
-        "sha1": "4088433b46b3b1ba259d78785d8e96f73ba02439",
-        "dest-filename": "klaw-1.3.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e",
         "sha512": "793233955392511f89c5d0c57a911870132d67d42a75e7feae7cd675166e31b3b2c2ee6d3b6c3637baea8e800d67993dbf2c212fa06bd55463508813431e04f3",
         "dest-filename": "kleur-3.0.3.tgz",
@@ -7762,9 +6768,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0",
-        "sha512": "6516e7bdd83f371ab30bb2fd532ab37f8a6c8b538ce02b9cfac2409103e33ba5e440825335b7cad91b266f0f1fc75a769a465da76159628dbe2f05d863fbb020",
-        "dest-filename": "klona-2.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc",
+        "sha512": "a49881a625cc6ededd9335def06863feee057d738e6bdf1f3d6f9b8a1389e128e7a228f0789acd4e125f77789f5e95e14448e9a05da66551f519f4bd2d5de41d",
+        "dest-filename": "klona-2.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7783,23 +6789,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555",
-        "sha512": "eca23697618865af69daca733c8559058c8d2a437e7bf4903e99e395388f85d6c35b717cead74a2842f12a9cc9e6c814d7dc105ac00250b666a533d81de58ee7",
-        "dest-filename": "last-call-webpack-plugin-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face",
         "sha512": "c1e4feaf491391141d09d60236d90cc165d04cc12cc0aac50649b872440e315861aa120c235513da1323fb58a28088604999b98139ab45704da06520693635c4",
         "dest-filename": "latest-version-5.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.4.tgz#882636a7245c2cfe6e0a4e3ba6c5d68a137e5c65",
-        "sha512": "bbdde46f67cf6c8adfcc1b8b8d913ec3e7c96d450c84d0d7c4d98c7daa8d8297d07f508ee5949ed8b7ec9c1a95024ee2ff6345e3c392a118fe5ded954fe944f1",
-        "dest-filename": "lazy-val-1.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7811,16 +6803,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4",
-        "sha1": "f6995fe0f820392f61396be89462407bb77168e4",
-        "dest-filename": "lazystream-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835",
-        "sha1": "308accafa0bc483a3867b4b6f2b9506251d1b835",
-        "dest-filename": "lcid-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.1.tgz#494c831062f1f9408251ec44db1cba29242a2638",
+        "sha512": "6fde0688d1d0372e89353aede70eb33727df32b3645d96f72939026496f6575c5a1060a4d3ddef919da3937b6969e3f7dff3a25c2f96bcaf40c5479b9dfe676f",
+        "dest-filename": "lazystream-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7860,37 +6845,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00",
-        "sha1": "1c00c743b433cd0a4e80758f7b64a57440d9ff00",
-        "dest-filename": "lines-and-columns-1.1.6.tgz",
+        "url": "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.4.tgz#f4507d043d7058b380b6a8f5cb7bcd4b34cee082",
+        "sha512": "6df4c837b944b22a280a87122124d65e489626446ab4bf7062d632fbc10add8e35aa1de6a703d4d327133a08dd63d12bc1709cf10cab429f366dd2f45e49bdc8",
+        "dest-filename": "lilconfig-2.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0",
-        "sha1": "956905708d58b4bab4c2261b04f59f31c99374c0",
-        "dest-filename": "load-json-file-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632",
+        "sha512": "ef297295eb1943f3d5dbd8e110397751f8e8e995fb802a89af917b3caaea73ddefedfcd2ca6b75069c0453c9c0517b3cab3cefaa16e384ae50660e8cb7f1e406",
+        "dest-filename": "lines-and-columns-1.2.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8",
-        "sha1": "7947e42149af80d696cbf797bcaabcfe1fe29ca8",
-        "dest-filename": "load-json-file-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357",
-        "sha512": "26c9abf3d45c5c62308af158db515c46b8ac6197ef2cc4d6c7990e2dcf894f1b6904e1bac4c2f4bf36dce921101b614ef7fe05737c16e0b55c0790e619f95a47",
-        "dest-filename": "loader-runner-2.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7",
-        "sha512": "7e4a73f1e8dd9c4306decdfbc062f4ee24810e0f7d3bd0f9c9f944f5118d1f7851771f523b061f9c661d64e508662b4df04f84daf92adcc50c60cbcf625e5964",
-        "dest-filename": "loader-utils-1.2.3.tgz",
+        "url": "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384",
+        "sha512": "f76fa1bafc4cbd894ccccb748883ae91cc18045a64609769976c6c67b2eb95ac8eec4f123aff8925410ad7b07f74920700e2cc7e1d9d659fd8d7c5a0986b5837",
+        "dest-filename": "loader-runner-4.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7902,9 +6873,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0",
-        "sha512": "acfe05d21d916964af3c4903ec12c31509ef49ffa72bec2bdc44948cd4f2006a1baab8a3996f76cdcf923ba778a78075c21efe07f260d669107b93585041ed1d",
-        "dest-filename": "loader-utils-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129",
+        "sha512": "4cce7b55e1e9b6fe7af5dfc62a1e9301877329b9700cd8ae98e7641677a38c3d17c131fcecaf74c373bb022251a9d4285f282f8b55504c94cb1a1265ed6a80ec",
+        "dest-filename": "loader-utils-2.0.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f",
+        "sha512": "1d597d66a71c422859ec933ce5d728d4cbcef46f8e36fc6819af6b921cc5b277862ca4948358097fd6d6ce146172f9b6a828615a979b4213f8e2ac6328850269",
+        "dest-filename": "loader-utils-3.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7930,9 +6908,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d",
-        "sha1": "0ccf2d89166af03b3663c796538b75ac6e114d9d",
-        "dest-filename": "lodash._reinterpolate-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286",
+        "sha512": "88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553",
+        "dest-filename": "locate-path-6.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -7951,13 +6929,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f",
-        "sha1": "f31c22225a9632d2bbf8e4addbef240aa765a61f",
-        "dest-filename": "lodash.flatten-4.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe",
         "sha1": "bcc6c49a42a2840ed997f323eada5ecd182e0bfe",
         "dest-filename": "lodash.memoize-4.1.2.tgz",
@@ -7972,23 +6943,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab",
-        "sha512": "f38bd81712249a2754885c62740fca8e31fda40c9ca96fa1f7cd23ec5bb3e6ac51b4ef69801ecc0c54ddcacd4dec0e6672e711883c84ab87eeb258c8b51d53fc",
-        "dest-filename": "lodash.template-4.5.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33",
-        "sha512": "b2d80bcfe8b701af666609e3aff3bebfdaee299b0fb27772eea3d939c85baa4d9c9d353565a95d28afafee6e785a8288cb18ae3194ca4f61fcd45f0178073765",
-        "dest-filename": "lodash.templatesettings-4.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193",
-        "sha1": "5a350da0b1113b837ecfffd5812cbe58d6eae193",
-        "dest-filename": "lodash.truncate-4.4.2.tgz",
+        "url": "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438",
+        "sha1": "edd14c824e2cc9c1e0b0a1b42bb5210516a42438",
+        "dest-filename": "lodash.sortby-4.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8007,9 +6964,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197",
-        "sha512": "1deb278b8b395245a4c0218931018087bd4f68b52628533ad1d1efab4ce2fef0e186bcee93ee0680d6d35c9d766184099fa64a0433488d872e4062ae76faab23",
-        "dest-filename": "loglevel-1.7.1.tgz",
+        "url": "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503",
+        "sha512": "f173efa4003cbb285fb5ebbca48bd0c69259ed2618769522bd9a46cbab05b01b8a458ffbad019abde75e07c68af99932ababa930554bffd016eaf398cdf4722e",
+        "dest-filename": "log-symbols-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8021,9 +6978,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.7.tgz#077c705d5c82b33a421618c529fccebd69a111fd",
-        "sha512": "74052b317e414713fb76bfaa0d6cda6e584663a4aa5f3b424b8eac5b5d708eecc4c5029997918b5f6c8c186aa0e0091d8e07e37ad9dd714f95475c682e1964a4",
-        "dest-filename": "lottie-web-5.7.7.tgz",
+        "url": "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.8.1.tgz#807e0af0ad22b59bf867d964eb684cb3368da0ef",
+        "sha512": "f60222cd600395a1c2d860adf83fb236993997672565016a9d5596215758d0b9f10bfb8b6b7f5d625b407b77dc982fe1ad9d88510f1d2e56343bddf83698eced",
+        "dest-filename": "lottie-web-5.8.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8056,13 +7013,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920",
-        "sha512": "2a9340450037230bfe8d3034bad51555bae1f8996baf516fd1ee7a186cc014e5cdedd93f16f89a0d6f0b1e62b9d8395c1f858fda7ea023cbcdd5a7ac045828f7",
-        "dest-filename": "lru-cache-5.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94",
         "sha512": "268e9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88",
         "dest-filename": "lru-cache-6.0.0.tgz",
@@ -8077,13 +7027,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5",
-        "sha512": "2d2f57f9d73c28bc5709bf1d9e2efd7cb208500e55c99a328d2302c1396e697034a36edc08ad1b857929830fac4d75693f2fe548ee7b8a5462c6a934bc39ad44",
-        "dest-filename": "make-dir-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f",
         "sha512": "83715e3f6d0b3708402dbffa0b3e837781769e0cded23cfbb5bceb0f6c0057ea3d15e3477b8acbfb22b699dd09fdf8927f5b1ad400e15ea8b9fa857038cfde1b",
         "dest-filename": "make-dir-3.1.0.tgz",
@@ -8091,23 +7034,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c",
-        "sha1": "e01a5c9109f2af79660e4e8b9587790184f5a96c",
-        "dest-filename": "makeerror-1.0.11.tgz",
+        "url": "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.12.tgz#3e5dd2079a82e812e983cc6610c4a2cb0eaa801a",
+        "sha512": "266a82bd4866b78de669d9691731b8050cc6d99de6eadbd00cd29d0a56673b755b22e749626c6c4f414d24c7a2076f894d295341349b53c41d7ac566c097262e",
+        "dest-filename": "makeerror-1.0.12.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
-        "sha1": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
-        "dest-filename": "map-cache-0.2.2.tgz",
+        "url": "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d",
+        "sha1": "d933ceb9205d82bdcf4886f6742bdc2b4dea146d",
+        "dest-filename": "map-obj-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
-        "sha1": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
-        "dest-filename": "map-visit-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a",
+        "sha512": "85d375c15ad96dbdbd7811a21a325b78ff096ca8ead6eae41c9fcb20ffcd638f0c6754155d4b10055d46d73bd81479f55c4d3a7308c1b0e2362b75259e3d585d",
+        "dest-filename": "map-obj-4.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8115,13 +7058,6 @@
         "url": "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca",
         "sha512": "3a478368067f6d00b1785028ccce793ca70a534c8930f1a27cbc15e108238adbbee4ca007d240de25b0b25e5d9d5bf30d31fbf12675ae8c6605d2d63bec6a99e",
         "dest-filename": "matcher-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f",
-        "sha512": "c62b4ff96c4d3dc4d33a09d325cae1334c6f74f7a98a93d27f723c108a4629e14b8eddcf9492c80c6deef045f9dd922e6e46fee54dbedeb10b6291211e1cdd92",
-        "dest-filename": "md5.js-1.3.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8147,16 +7083,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552",
-        "sha1": "3a9a20b8462523e447cfbc7e8bb80ed667bfc552",
-        "dest-filename": "memory-fs-0.4.1.tgz",
+        "url": "https://registry.yarnpkg.com/memfs/-/memfs-3.4.1.tgz#b78092f466a0dce054d63d39275b24c71d3f1305",
+        "sha512": "d5cf553d5bd6e4fec8f39737e7301d12bd530f9f85d75213a081c896b54871f95f9f33e425ad19a1812811d6033fc2a03c5a1267fa290eb52c028656ca6de6b7",
+        "dest-filename": "memfs-3.4.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.5.0.tgz#324c01288b88652966d161db77838720845a8e3c",
-        "sha512": "8c0d2b754e4aa10302d1eea9a68351b69a7abe316aebe358eebf21cb09c2ed5fb55e3fccb47c0621b07541a2bf76e9f28d6b5e2739a4a5dee8a1e5a0d744fb18",
-        "dest-filename": "memory-fs-0.5.0.tgz",
+        "url": "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364",
+        "sha512": "fa86d26e539099185cc81b7ad9fbab42a440429372597a3c06e4396cdedd1bcc26c10fafc072a9feb0850f80ab4cff02b03403d6c8e867de0ae35ed711493c21",
+        "dest-filename": "meow-9.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8189,44 +7125,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0",
-        "sha512": "8e8d4e7d1e13684c1de473abb79fad019f66a93e239a9340bac5edc9f373a959bdba249815994a335c182f8a14edacd95bf3f1416e77c0cd12e8e47524735ada",
-        "dest-filename": "microevent.ts-0.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9",
+        "sha512": "a519b3c3f5d47305c6a43f5a23dabfd173b02cdca08c44c9f32d1aa34c1daa9aebcc36b8627c4b733edf41166bf2fa21f15d7490684005b35c1d5939c07816c2",
+        "dest-filename": "micromatch-4.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23",
-        "sha512": "3168a4825f67f4cdf0f9ba6c6371def0bfb0f5e17ddf7f31465f0800ee6f8838b3c12cf3885132533a36c6bae5a01eb80036d37fcb80f2f46aaadb434ce99c72",
-        "dest-filename": "micromatch-3.1.10.tgz",
+        "url": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c",
+        "sha512": "e72f00e7a8e0ed7550c7699bbf596ee3d351e1da24467859613b4bf8a19f69adbbbaae294935e4c10905265e29911332345cff12d6034a48a2107c7717b50dea",
+        "dest-filename": "mime-db-1.51.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259",
-        "sha512": "cbb1691d26cc50ca323db6144b33ba3da67a17246740ea47b8ac1ba351be2a7724f795d553840088a7461278f9c30a12ecf94e82d857ff4f6ee62149f9a61fe5",
-        "dest-filename": "micromatch-4.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d",
-        "sha512": "d75e5f2e1bd956a5b01cf6c29729edc4455f5437e5f432cb4ee26fab78363bf3b18bc022368b801ef0d2cc74b4be250973e579be6ddeabdd57c2a9fd769e2344",
-        "dest-filename": "miller-rabin-4.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee",
-        "sha512": "b2f5da3fc510459e4aee8afe6667cd860db15f7c8a0cc533a9a76c4aa8b83421ff2a899c1fbe4c00c60019596f5e7e3e6ffc4e3e14b7236b87291533be363b05",
-        "dest-filename": "mime-db-1.46.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2",
-        "sha512": "63f8ccb7f4b9b11f4e6aab5e26db25b0564a58e208a8c002b094a21e0865080ca17fb8df5588ca0662e25fc3a0a56796f9f8c9d9bf80cfaf5a3c53e450e63ac5",
-        "dest-filename": "mime-types-2.1.29.tgz",
+        "url": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24",
+        "sha512": "e9c3faf765b0188b3d5d774e3b8fbe37eeea8eabf4aeac7156f2775473e1fd273d99565c40ff991a190a893bd631046bdad6c79093ff627ed8d27a5bdd906ce0",
+        "dest-filename": "mime-types-2.1.34.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8238,9 +7153,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe",
-        "sha512": "b6a921e3b17329e08f0f63d488f07aa646cccec09ab23c407c2eb6fd66a9e6aad459c6feb056ac5d40b923781833988133cbff4299f850ad31fa3d221f214f0e",
-        "dest-filename": "mime-2.5.2.tgz",
+        "url": "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367",
+        "sha512": "5123e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242",
+        "dest-filename": "mime-2.6.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8259,9 +7174,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz#15b0910a7f32e62ffde4a7430cfefbd700724ea6",
-        "sha512": "9fd040f0ba2790e916d7fce7f886cb3d09a8bec2f4c0c6fdcb1ef97cc25065fd97d59a1e73dc9366dc8c78f732bb5f703e49856f365903a7cb4e8b6916142c38",
-        "dest-filename": "mini-css-extract-plugin-0.11.3.tgz",
+        "url": "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9",
+        "sha512": "cf4c9623ee050ebaf0792f199ade048f91dd266932d79f8bd9ee96827dfe88ae5f5b36fa4f77e1345ab6f8c79345bd3ae1ce96af837fc2fd03cd04e33731cd19",
+        "dest-filename": "mimic-response-3.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869",
+        "sha512": "23d8f0327d3b4b2fc8c0e8f7cd59158a4d894ef8296b29036448a02fa471e8df4b6cccb0c1448cb71113fbb955a032cb7773b7217c09c2fbae9ecf1407f1de02",
+        "dest-filename": "min-indent-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.7.tgz#b9f4c4f4d727c7a3cd52a11773bb739f00177fac",
+        "sha512": "7ae5a675d7f4b24f4dbf53b481f79e500bc09284a55a770d2c5efb0b44cfdbe5a83efcbc9801ca3b331a8dc0b3d9dcefcaddc2360c5bd686c81151484716a2a6",
+        "dest-filename": "mini-css-extract-plugin-2.4.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8273,16 +7202,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a",
-        "sha1": "f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a",
-        "dest-filename": "minimalistic-crypto-utils-1.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+        "sha512": "c891d5404872a8f2d44e0b7d07cdcf5eee96debc7832fbc7bd252f4e8a20a70a060ce510fb20eb4741d1a2dfb23827423bbbb8857de959fb7a91604172a87450",
+        "dest-filename": "minimatch-3.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
-        "sha512": "c891d5404872a8f2d44e0b7d07cdcf5eee96debc7832fbc7bd252f4e8a20a70a060ce510fb20eb4741d1a2dfb23827423bbbb8857de959fb7a91604172a87450",
-        "dest-filename": "minimatch-3.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619",
+        "sha512": "438afc82177cd3284eff48f53b7076063c1e5f77e21e0f5c74ec2325dd89efa435df973e343c460aa758290d52281b857e059b014cc17ef6233d411e360a8dd4",
+        "dest-filename": "minimist-options-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8294,51 +7223,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617",
-        "sha512": "e93ea51f41fc386f642139bf266ead768a086e8806f5ed2d2e0a58ea6a615d29bf03dbbc36ad6bc811be42ca62b9bf4b8d69413ec3d2ded590fc1a2dab815dc4",
-        "dest-filename": "minipass-collect-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373",
-        "sha512": "266412618a4f52a5f92729f5997691c0e75ad6e43c1cfe4a013fe80d22c2cedd41611850534fe10edb01d6e7d97c4133319f5a0159ac070f3e156b085e50a55b",
-        "dest-filename": "minipass-flush-1.0.5.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c",
-        "sha512": "c6e22aedc20eb74f513d1275f60762e1bf9188dbc31587b9247fa080dbc1a86aa941772bbb73dc466399b8704a58ad53c5ff7e710f8731537877acf8e8b64fec",
-        "dest-filename": "minipass-pipeline-1.2.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd",
-        "sha512": "32077619d315cd8fb1dc827ea079d533e286de503973cb6769bc892a61d2686da4006a6e771b8e7fc4e80e486e985ed4ccc13b0de71b404f6e39984d9bb3ee26",
-        "dest-filename": "minipass-3.1.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931",
-        "sha512": "6c0c6c47c0557e3eb40d65c7137bb7d281f37e5e06ee48644ae3d6faabe977b8c54479bb74bc4e8d493510700227f8712d8f29846274621607668ee38a5ed076",
-        "dest-filename": "minizlib-2.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022",
-        "sha512": "c78ef54ac56352d051b5cbdde01cca13d9050beff64de5a0282830d1b65cc356fd9765f7417e6f096805f8a6996989bced2b3ffeb1e75abcaea43ae02ef99290",
-        "dest-filename": "mississippi-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566",
-        "sha512": "591a039fffe65c1889d47e34aea6b7bc7d2da1e3f04ac19be398889d6953c926be52ee24ded6144b16b6bf52aa0222edbe5ad2cda131a92d60b64f7a03dcef10",
-        "dest-filename": "mixin-deep-1.3.2.tgz",
+        "url": "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113",
+        "sha512": "80a2dc444321b6e651c1101fa8fdd1156f932b826a029541b4e21fb55823b8006902da7184f19a0dc7ef6e136f0f407c883d6852bfedc57df936371a63a36cfc",
+        "dest-filename": "mkdirp-classic-0.5.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8378,16 +7265,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92",
-        "sha1": "be2c005fda32e0b29af1f05d7c4b33214c701f92",
-        "dest-filename": "move-concurrently-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/move-file/-/move-file-2.0.0.tgz#83ffa309b5d7f69d518b28e1333e2ffadf331e3e",
-        "sha512": "71d91d84d0a06cfe5dbd2e2d946c596c3fa79688a8f4622298fe7b123a858702dc3239d4f9724a019ce59a0fd337f00ad4bb8d01d4d2be6dc23cf3f85e4bf489",
-        "dest-filename": "move-file-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/move-file/-/move-file-2.1.0.tgz#3bec9d34fbe4832df6865f112cda4492b56e8507",
+        "sha512": "8bda8b5ba82a6e82791edf1b6ae662eca9539d0dd0169042bccbc57c47070032a01c6789f4164c3bb485093c073d5f506b476ef43618d58c77a2a946b77d275c",
+        "dest-filename": "move-file-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8395,13 +7275,6 @@
         "url": "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8",
         "sha1": "5608aeadfc00be6c2901df5f9861788de0d597c8",
         "dest-filename": "ms-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a",
-        "sha512": "b60a7e765e5c1a4dbcbad624b41b2b16a03b1ca82b8603ec83a67f11f856238825d47c2af01fc6998ff4a1767a9c5f210d57ac4bf1699d8683fe439685842fca",
-        "dest-filename": "ms-2.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8434,37 +7307,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19",
-        "sha512": "336b9fcc888834a0ae0df052014af5bd643ebee55c03d92ac7c24952c6d08bac9fd6e191c9bec77e975f52be6a2d77f707fb7c74fbdc8e128c9a57e73f8ec4cd",
-        "dest-filename": "nan-2.14.2.tgz",
+        "url": "https://registry.yarnpkg.com/nano-css/-/nano-css-5.3.4.tgz#40af6a83a76f84204f346e8ccaa9169cdae9167b",
+        "sha512": "c1f72f88907a34ec432037ebed1167fc695a37b23f0617b8777f59442277c6f657eb42d57b6a99fab0ea338f679b8613f358008f34be66496128ffc69df9ee6e",
+        "dest-filename": "nano-css-5.3.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/nano-css/-/nano-css-5.3.1.tgz#b709383e07ad3be61f64edffacb9d98250b87a1f",
-        "sha512": "10d3c8c8dcc0350472615bdbeb66a30ddecf0322204b62c85274fd7b08a1e32ad74995f884aa14c2cb32f168d41fefa410e039c144cc80d9d5ee4a399f7e2450",
-        "dest-filename": "nano-css-5.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.32.tgz#8f96069e6239cc0a9ae8c0d3b41a3b4933a88c0a",
+        "sha512": "17c99fed1de24fd6ef4e10685b8b465e15c51c272dc8289450fad617c59a4ea6b787de9df50c9b91279b6b8dd754e384de888b7e45437b86d3f0c7869a4ad3c7",
+        "dest-filename": "nanoid-3.1.32.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844",
-        "sha512": "ff66546895f600db8bb53bea4e582a050349a103b7f7c2b2260665a0bd0f6640b4769cac8e771150fb057b70d43f3cffcb787ebbb0b8ea7a7c44cbaf1778ec49",
-        "dest-filename": "nanoid-3.1.22.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119",
-        "sha512": "7e9a1ed93d116c7c014c150e7ed01f04f683122d3ab9f6946a2d2613a627d6469c7374a74c4adf6ff87e5fde155f323ae2b2851d82265d2bddc061829b03aa08",
-        "dest-filename": "nanomatch-1.2.13.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/native-url/-/native-url-0.2.6.tgz#ca1258f5ace169c716ff44eccbddb674e10399ae",
-        "sha512": "9386c30bced6b60add0f7eb6819cface889742b978d24625066a5f9928f044ed5553457971cc094e5c6e13bd85ea6dd5d2f735c4e7fa9f75023fd4327ab46a98",
-        "dest-filename": "native-url-0.2.6.tgz",
+        "url": "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806",
+        "sha512": "38d99152a2bbce3ec3597d03f400ded37c1bc0e059c4d01f176d0f9467c2590703dfefcc6a44a1207accab1f58c0f4dfc43745d732de2fe44666247d90630b76",
+        "dest-filename": "napi-build-utils-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8490,13 +7349,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c",
-        "sha1": "ca86d1fe8828169b0120208e3dc8424b9db8342c",
-        "dest-filename": "next-tick-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366",
         "sha512": "d67878e5d79e6f9a25358ede5fcd8190f3bb492c51e524982623d3ad3745515630025f0228c03937d3e34d89078918e2b15731710d475dd2e1c76ab1c49ccb35",
         "dest-filename": "nice-try-1.0.5.tgz",
@@ -8511,9 +7363,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/node-abi/-/node-abi-3.5.0.tgz#26e8b7b251c3260a5ac5ba5aef3b4345a0229248",
+        "sha512": "2ed1ef3480603b2e663bc98f114b64096fd809159810ab2122faa17b51871f25c41c40799a0202c989c0725e2a6a7dee15e451384aca1b36ad1473dfea40f15b",
+        "dest-filename": "node-abi-3.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d",
         "sha512": "89b3cade203ebda6357848c44a442433405b0aa14e6993225d14ed741d2eedbe1d8ed63a267b23bcf7541d5320eb142ddc1f1fa534d61c8f40f800e333d7ebce",
         "dest-filename": "node-addon-api-1.7.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.2.0.tgz#117cbb5a959dff0992e1c586ae0393573e4d2a87",
+        "sha512": "79acecab3c06da5b24bb306a0863e2ec07365203a8333f0954e5d5853bef3c3621b61bcda5e7f1f23583f0da7b1affb64b3d0594f5999349c9574cf9f7c5a7f1",
+        "dest-filename": "node-addon-api-4.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8525,9 +7391,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3",
-        "sha512": "3cf9aef1e11e1bdb1a114bc8f7b7e6e0e6315d507a6c5bf2353ca250e062721069146f00d4b8f0ddb63adbee683a30c430746777463b1d0fb1eeecf13b30ba24",
-        "dest-filename": "node-forge-0.10.0.tgz",
+        "url": "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c",
+        "sha512": "15cbed6dbfb305c6576d34d5c2a180e56f8c2818f9e948d545ebef721bf95eb7325db98d75eb1f64bdfb9e571639fa601e1826c40a70ded41b4ebe02a8d997e3",
+        "dest-filename": "node-forge-1.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8539,30 +7405,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425",
-        "sha512": "87fcdc0fc1fd91a0d9f402d45b0941503a3a4ca17c6bba8148248419f8d354861eaac8a848a6805fe04decd822306a7a8922176773f1802bbc292ddbef560ae5",
-        "dest-filename": "node-libs-browser-2.2.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40",
-        "sha1": "8d9dbe28964a4ac5712e9131642107c71e90ec40",
-        "dest-filename": "node-modules-regexp-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.2.tgz#f3167a38ef0d2c8a866a83e318c1ba0efeb702c5",
-        "sha512": "a093fff4d01d77dfb1d90fab7e9841d912421e3a1def445c44b8e8b223cc32ee608c87f05673941aada76d38d351b9b2d0327fb452154f7d3e41ede7ce5e1326",
-        "dest-filename": "node-notifier-8.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb",
-        "sha512": "cd1e87a13e8bacb091070ba49ab55b1efd04a4442392c3ba1a615c65042e080cb5dfd044b2854a3d89dfde3a278185bcddf01ad6da2b2c6630c71932fe9dbcb2",
-        "dest-filename": "node-releases-1.1.71.tgz",
+        "url": "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5",
+        "sha512": "0aacb337acfb43a68c785fe4b5c3154f38401c21297fc48e6abc29ce97fca4d058da4e7fa0cdf850795d530a7c54a23bbb172dd87c5245d26305a65e112cdcc4",
+        "dest-filename": "node-releases-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8570,6 +7415,13 @@
         "url": "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8",
         "sha512": "ff908c3774f44785d38f80dc19a7b1a3eae8652752156ff400e39344eae3c73086d70ad65c4b066d129ebe39482fe643138b19949af9103e185b4caa9a42be78",
         "dest-filename": "normalize-package-data-2.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e",
+        "sha512": "a765b5b20aa28f7ccc332442d3aec3835e9b7f3547fb0ee1c9e826a48bd9e09363aad18e54022f2e68c1c77c8fed84def6f289824a0d38f8f0406a200e831714",
+        "dest-filename": "normalize-package-data-3.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8595,23 +7447,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c",
-        "sha1": "2cc0d66b31ea23036458436e3620d85954c66c3c",
-        "dest-filename": "normalize-url-1.9.1.tgz",
+        "url": "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a",
+        "sha512": "f546421511d074dadf4e91a0f3ed4834883ddc1eb3134697315164c35585c2f3b84a5672c14e9a2e0e4e7f4029fcf81c6d2c382cdc6f3165cc7ae8303025f400",
+        "dest-filename": "normalize-url-4.5.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559",
-        "sha512": "53e2498bb76e175a3ebb6a729dba76cd70d6dbf3c00e00b7d1fd06b0766d461f8739c5c79f0d77ed3acd972c7146f596e5f8ca7776dc2c73f1a1f5ae0a369e66",
-        "dest-filename": "normalize-url-3.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129",
-        "sha512": "dace3bcb353175ec5fd4e872462e049bcde2424d1a3efc1375db45cf8867492c3d74212c2c419fe92c083bcb2cff5f52f6205be6c25a3ae4ef4c60de648d3405",
-        "dest-filename": "normalize-url-4.5.0.tgz",
+        "url": "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a",
+        "sha512": "0e52fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec",
+        "dest-filename": "normalize-url-6.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8630,13 +7475,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f",
-        "sha1": "35a9232dfa35d7067b4cb2ddf2357b1871536c5f",
-        "dest-filename": "npm-run-path-2.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5",
         "sha512": "0db97803f55f89518b810bf6f5444bf71b2153c5c363519e2f2f9fb1a675000f090d27e3bebe4fe7ea7345b5aa45207193afc35bb30887c95333f3da1a73f692",
         "dest-filename": "npm-run-path-3.1.0.tgz",
@@ -8651,6 +7489,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b",
+        "sha512": "dae52a6b3b8a95369223f742f00ce2714724efe22b11a3a737f7b48dddd7b6dd4a706a70c77d2fe7498bee83f2aff87d6cbdc4e1a65c715c29c0ffb95bd56392",
+        "dest-filename": "npmlog-4.1.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c",
         "sha512": "59e04e763bbc4a7ccf379bd3509631614c4b797a426953f98b97b42c5f1f83b58e445d9677bc055ffa64d2d61993bb3c4fe27b54bcb40dae89d7ec024f402d1e",
         "dest-filename": "nth-check-1.0.2.tgz",
@@ -8658,9 +7503,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede",
-        "sha1": "6f682b6a027a4e9ddfa4564cd2589d1d4e669ede",
-        "dest-filename": "num2fraction-1.2.2.tgz",
+        "url": "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2",
+        "sha512": "8add6f13de7317a7534fd941b186f1bea8744a8cb848fa307218f45011a3fd5e9c4cf9d75ed40e3d46e167a0a61b3003feb5b6d8b40ae84f7aa5c7495e4e00e3",
+        "dest-filename": "nth-check-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8679,13 +7524,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455",
-        "sha512": "7dec6150514f4c657cc9b02d48819b57a80e912bfc52d45b0c19c0c8b430e103ca920365b07d81c8f1ad314a9d5a4a2ce98091980a958b0819ac973f9910f365",
-        "dest-filename": "oauth-sign-0.9.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863",
         "sha1": "2109adc7965887cfc05cbbd442cac8bfbb360863",
         "dest-filename": "object-assign-4.1.1.tgz",
@@ -8693,16 +7531,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c",
-        "sha1": "7e7d858b781bd7c991a41ba975ed3812754e998c",
-        "dest-filename": "object-copy-0.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5",
+        "sha512": "812711327d1b4b97c7f88bb0c881609e1f7305da380d5fba1a1ca099633d1f23494a04b4852729d5fe6f8ed9bba0820e893f6dad7ad284090b15273622a28d83",
+        "dest-filename": "object-hash-2.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a",
-        "sha512": "8b7069f624eac2168b641c469117e8e596c4d3b050453ecc1aef3e9cd8305bd22d1a9d53cc24f0d832c4a16c230a5c418ce148fe15a58d3026606084c26b673b",
-        "dest-filename": "object-inspect-1.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0",
+        "sha512": "1e8db3f346d522f265a07f98cd19a965541ef3bfaa01298150a6435a0c7d72ef8a0eb5f66431ffded332fa05db6444d51acd8cf1877139b3a1ed702d8a6f58d2",
+        "dest-filename": "object-inspect-1.12.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8721,13 +7559,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb",
-        "sha1": "f79c4493af0c5377b59fe39d395e41042dd045bb",
-        "dest-filename": "object-visit-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940",
         "sha512": "8b14f62f94c75ec029ca250f60a996fb6107a575dee488b733e7f87be6891401daa396a61515ba27438ee9cfcb53c05ee3bbad0b1d862fcf61c4607a5d298ab9",
         "dest-filename": "object.assign-4.1.2.tgz",
@@ -8735,37 +7566,37 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.3.tgz#c601c7f168b62374541a07ddbd3e2d5e4f7711a6",
-        "sha512": "ca6ee1ece65e6cd4bdea19f92097b252669685a48ce1256d00f3df34b4042363185823b67a0b084dbf6769bdbe8bf3f089bc7e4749ad9fe96d2895d149e4cc1a",
-        "dest-filename": "object.entries-1.1.3.tgz",
+        "url": "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.5.tgz#e1acdd17c4de2cd96d5a08487cfb9db84d881861",
+        "sha512": "4f2c668d4a198207783abad4d56eba14c0c6e82baa271b05bf299ec97239d7ebd02cdebbcd87d9b1ea6d4607bbd3790a41da38b9c72000a79b5c57110b3938fa",
+        "dest-filename": "object.entries-1.1.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.4.tgz#26e1ba5c4571c5c6f0890cef4473066456a120b8",
-        "sha512": "12c141b21b394545294046350f8abf9b9f6431fcf8609bf1b8d08972ffe35b0389af7e046959c6d7566b65ad141c1df09f3575c31f26e7c4f88502fc22e35795",
-        "dest-filename": "object.fromentries-2.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.5.tgz#7b37b205109c21e741e605727fe8b0ad5fa08251",
+        "sha512": "080c86e66590451881539ed17b814aa130635df0e8370745547d98d6d4bd3ea0ac7d44f2980a213a410c486dda44d2a6bf8955dceee9d5eb7b735f3baba6f29f",
+        "dest-filename": "object.fromentries-2.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7",
-        "sha512": "5adc5e292cdf0639732fe17d6fb33b85ec03cccc32f82f0d46cb0777562b365cc7cc80eb5dc5e234e32b7b374010ce145e2c6057ebef9f205e37b472825dadb5",
-        "dest-filename": "object.getownpropertydescriptors-2.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz#b223cf38e17fefb97a63c10c91df72ccb386df9e",
+        "sha512": "55d0e80b0bc923841d0ba9dd8e9a859a82f7ffe1f17df1416dc2732a2e61c0b2eaab1de675b79d4697d90dd2b44ab3926ae8fc5f81b306f9c3665e2f4cdedd3b",
+        "dest-filename": "object.getownpropertydescriptors-2.1.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
-        "sha1": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
-        "dest-filename": "object.pick-1.3.0.tgz",
+        "url": "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.0.tgz#7232ed266f34d197d15cac5880232f7a4790afe5",
+        "sha512": "3218d845f8f71819614a40c7a3a426be08d12d7436ce775a6dd7f79d7d324f264af6b3dfc5beae46901a73c1d734bcb51a9a96b59f35421e2fdee3a5b36b1102",
+        "dest-filename": "object.hasown-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/object.values/-/object.values-1.1.3.tgz#eaa8b1e17589f02f698db093f7c62ee1699742ee",
-        "sha512": "9e417a3df0c1f5a964394c697f51cd9bf42591e5b74917aa2f95977812e910926794f4af45a0d0a56de041392c4cdddf8095f884be364732b23a29fa7dfdedcb",
-        "dest-filename": "object.values-1.1.3.tgz",
+        "url": "https://registry.yarnpkg.com/object.values/-/object.values-1.1.5.tgz#959f63e3ce9ef108720333082131e4a459b716ac",
+        "sha512": "4146515b48a54373e73e96cdb6074d5753c36c4a8b22248507797e1271ad050ffc4944cb8f53d9c2d40700166d2e0c292594d2661b862ce1a4e7b0ebc7622f62",
+        "dest-filename": "object.values-1.1.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8812,16 +7643,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc",
-        "sha512": "3ea1e98200bd6cb57455e59c74a864a7163edc94f37ad2d2a930962ffcffb4521b23a1bc2428e89dd5e4953d498a77332f3d9789beb6b12a744ff80a4f82a4b0",
-        "dest-filename": "opn-5.5.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz#85883c6528aaa02e30bbad9908c92926bb52dc90",
-        "sha512": "c2a77a15d2366b9fc576888234d904bcb780fff9471df1b6e0b9f65e6daaa9d224e1a3a5b11d7c8f0a723a286a43cf38f56deabb60d7f1f398c69bd3323fbddc",
-        "dest-filename": "optimize-css-assets-webpack-plugin-5.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8",
+        "sha512": "5e014f3ccf81dbc16d0828126fd23eb3db33382d6f6514b0816b11500e72948c514e02a8cea8ce0ab54ea86b180013d82b9aa77ea0a5c594c505af0f2addafe9",
+        "dest-filename": "open-8.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8847,30 +7671,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f",
-        "sha512": "87205597a8aaa94389f05a917be97f812f07fa42988eb12775de4f9b531f06db04280d37f0792475b025ffbd840171b2a270ff3c5b2f9951be12f708a6588c06",
-        "dest-filename": "original-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27",
-        "sha1": "854373c7f5c2315914fc9bfc6bd8238fdda1ec27",
-        "dest-filename": "os-browserify-0.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3",
         "sha1": "ffbc4988336e0e833de0c168c7ef152121aa7fb3",
         "dest-filename": "os-homedir-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9",
-        "sha1": "20f9f17ae29ed345e8bde583b13d2009803c14d9",
-        "dest-filename": "os-locale-1.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8885,20 +7688,6 @@
         "url": "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc",
         "sha512": "b3bdd7c4e678ce9b7579d658673be1a856babaf41cd6fc146b42b405db4866040c0098fd21b79b1fe26480a65cf61f81d393ca1cb3939786a31b506636b55997",
         "dest-filename": "p-cancelable-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a",
-        "sha512": "c9c20bdbed55df6b61fbcb1c6e94efc8735a1ded36cf4b23821f755d78c093e65e5e83cde19e3a0d5527cddb28d1a5f829c90ac3414d3451dd8d9d94b19bf188",
-        "dest-filename": "p-each-series-2.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae",
-        "sha1": "3fbcfb15b899a44123b34b6dcc18b724336a2cae",
-        "dest-filename": "p-finally-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8952,9 +7741,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175",
-        "sha512": "cb76fc2a977c380378e388717c16c57e3d4563f463b5377cb73630854a8d617c747d7c76897e2668fe10afaaa120a6d05c8d36c132c075ae1f6146c36a04d417",
-        "dest-filename": "p-map-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834",
+        "sha512": "2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f",
+        "dest-filename": "p-locate-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -8966,9 +7755,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/p-retry/-/p-retry-3.0.1.tgz#316b4c8893e2c8dc1cfa891f406c4b422bebf328",
-        "sha512": "5c4e86e3e6134e44f66b45166f692365ef313707fc6c86e7aa973f212fe274e055872bdeb3498ae4e2607a8723c7bab9a6f5ffea6db7c6ecd53d84f5b8633bdf",
-        "dest-filename": "p-retry-3.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.1.tgz#8fcddd5cdf7a67a0911a9cf2ef0e5df7f602316c",
+        "sha512": "7b6c5718d859399d257e047d90bdf8886954f0dfca3b4c599d0c5513075e3afa6a34341f767c48622cef5ad2bc4609546b76c6a88f20d11fc175fccb33146488",
+        "dest-filename": "p-retry-4.6.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9001,13 +7790,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.2.0.tgz#9049ca37d6cb2182c3b1d2c720be94d14a5814fc",
-        "sha512": "3f6bd2988bb7f2e225bdd714edf0e4cabc63df7813532fc004ee5951b1a8c31342a2906afcea03e366cfe1498cac9a0fca4e14a9fd26bb79ad5818470990fcca",
-        "dest-filename": "parallel-transform-1.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5",
         "sha512": "457963ef3098a2445ea96a4e3c7f68622bd4ccb619e6f00f21f1260933558a8b02efc17c1741fdcbb4fb806d8cdfdca682eb7117981c144b326504a987d069dc",
         "dest-filename": "param-case-3.0.4.tgz",
@@ -9022,13 +7804,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4",
-        "sha512": "467651a3510f53a2419eb6b6bc61e3d32869e9e6f28c166999408b1d6885871973bc1082a40b99ede96c069d4f5406d0374ff4e150ffd7dadfce5052c0bb2d33",
-        "dest-filename": "parse-asn1-5.1.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8",
         "sha512": "924cb01a909c45886a408721696a99f3be70ce94bf6cc2a1cf91e7377a7bc2f7894e44edc8007f0259d2d1ff03152a985b54fcdadeb2100904701f80d48dcc6d",
         "dest-filename": "parse-entities-2.0.0.tgz",
@@ -9036,30 +7811,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9",
-        "sha1": "f480f40434ef80741f8469099f8dea18f55a4dc9",
-        "dest-filename": "parse-json-2.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0",
-        "sha1": "be35f5425be1f7f6c747184f98a788cb99477ee0",
-        "dest-filename": "parse-json-4.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd",
         "sha512": "6b208abe6fe98421b13a461148233cda20f072df3f1289d2120092c56c43eef7ba8c7820b059787d955004f44d810a0a8ae57fa1d845ac6cd05d9c1b89f0bc46",
         "dest-filename": "parse-json-5.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d",
-        "sha512": "907b7b9332e84bd54165f52c88a8efe379abf7579af94d391322a412daa9eef35b1f199a56e12a37b5f17845671ab32d60e0311ab0c49528bde8aec480ed7308",
-        "dest-filename": "parse-ms-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9085,13 +7839,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14",
-        "sha1": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
-        "dest-filename": "pascalcase-0.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148",
         "sha512": "4b4be1fd911a7d9d7b85b860a9d9e9ba72837f31d089b422cf1f60f3211fe5d71593728e7e539f76e7d15d05fc092124c8e430b8cfdb373d46c0abc58f9e2469",
         "dest-filename": "patch-package-6.4.7.tgz",
@@ -9099,23 +7846,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a",
-        "sha512": "05aa40e34347202392f94497f52378b7286af80d91acdfd6b3917467968c1c3a7df0597cea55fc3ad8bc07bb8df772f821fbf87c738403ea50c3cee098c3bf95",
-        "dest-filename": "path-browserify-0.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0",
         "sha1": "cc33d24d525e099a5388c0336c6e32b9160609e0",
         "dest-filename": "path-dirname-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
-        "sha1": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
-        "dest-filename": "path-exists-2.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9137,13 +7870,6 @@
         "url": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
         "sha1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
         "dest-filename": "path-is-absolute-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53",
-        "sha1": "365417dede44430d1c11af61027facf074bdfc53",
-        "dest-filename": "path-is-inside-1.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9176,20 +7902,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441",
-        "sha1": "59c44f7ee491da704da415da5a4070ba4f8fe441",
-        "dest-filename": "path-type-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73",
-        "sha1": "f012ccb8415b7096fc2daa1054c3d72389594c73",
-        "dest-filename": "path-type-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f",
         "sha512": "4f6654b1d6451e0037bb87b93df3db8ddec70c3a713e741be633744ab0ec8cd4ae5571c9aadc139d6a86d01d6366b82627fee58f51265480725add60c46916be",
         "dest-filename": "path-type-3.0.0.tgz",
@@ -9204,16 +7916,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94",
-        "sha512": "e048f2d4e3f18bd7f6b6dd6b455ec6a3bce67c343e65e72d110cf7546510860abad87b4844f0f21bf26d9f0231b3ac77b8d330a3657bab57ccbca8dbf939e9aa",
-        "dest-filename": "pbkdf2-3.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.3.tgz#932480d46cf6aa553c46c68566c4fb69a82cd2b1",
-        "sha512": "9a901ccacc912719880817016b92171fb4993ef5a4720866e8593c45e9284b7bfe0696d2ce5673b966ccc7e197ae55301128bda876abe2754464d30aca5207be",
-        "dest-filename": "peek-readable-3.1.3.tgz",
+        "url": "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.0.2.tgz#a5cb847e347d3eccdc37642c82d2b4155c1ab8af",
+        "sha512": "f5f31acface8c70f72a4ed4a672e510c9812ba912dbb443e83f3aaaac5475f7aca191f2a7a144b633b050116786d5bddbdf9272a25efb836e43273b583a711a5",
+        "dest-filename": "peek-readable-4.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9232,16 +7937,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz#efd212a4a3966d3647684ea8ba788549be2aefef",
-        "sha1": "efd212a4a3966d3647684ea8ba788549be2aefef",
-        "dest-filename": "phantomjs-prebuilt-2.1.16.tgz",
+        "url": "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f",
+        "sha512": "70c943a9a2c4a9f49a5bc67b379270fa5c885bcebd1334fbdff179961b58f5c2c6a15c525f39df81f5cc3b46792b4a344364e44d7abed0a16c76749ede30d588",
+        "dest-filename": "picocolors-0.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad",
-        "sha512": "ab433ff5e647ce6af402e957c8fc0d7d98edc19fd105995b3772b7084ad5ae4e744f6012608ec1c9ed04bde90563720fd4db760c7bb4adef95d991c8a4c92e5a",
-        "dest-filename": "picomatch-2.2.2.tgz",
+        "url": "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c",
+        "sha512": "d5fca0ae84cb947bbaeb38b6e95a130eff324609b415c71e72cb2da3e321b19d03fc3196dac9bc13c0235bb354e5555346de46c5b799e6a06e26bf87c8b6248d",
+        "dest-filename": "picocolors-1.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42",
+        "sha512": "254ded7874cd8e6136542185cee63c117cc20d5c04a81d9af1fb08bf0692b4784058911e55dd68d500fcd0253af997445d748b6d2b2e2f0263902056a9141454",
+        "dest-filename": "picomatch-2.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9256,13 +7968,6 @@
         "url": "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176",
         "sha1": "e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176",
         "dest-filename": "pify-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231",
-        "sha512": "b81f3490115bfed7ddebc6d595e1bd4f9186b063e326b2c05294793d922b8419c86914d0463a9d252b082a438fe8e00815b8fb18eadcb9d739a4d8d9fa0795da",
-        "dest-filename": "pify-4.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9288,23 +7993,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87",
-        "sha512": "5ae36a2d36cc237b667de7f64cac654260222c72ad16196c0999cf229bafd8ec3444354ef257f2d4ea5fe0d53394c5cb8cf97e31e9fb02e55d5fa4c0facfae18",
-        "dest-filename": "pirates-4.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b",
-        "sha1": "f6d5d1109e19d63edf428e0bd57e12777615334b",
-        "dest-filename": "pkg-dir-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3",
-        "sha512": "fc4e7b018928790db9aa4c4c8f93c1395805f0a8aefe1edc612df4679f91ed66a208205f2eae7c648fdd49e68429bf565495799ffd37430acddc8796205965bf",
-        "dest-filename": "pkg-dir-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/pirates/-/pirates-4.0.4.tgz#07df81e61028e402735cdd49db701e4885b4e6e6",
+        "sha512": "648ad53c7f80e760f0f384742f7fd54bd3a9d383ee436484a092fa6e4b219a24e273f1e57725bd4dfee81f99a125904aecd983c76eef48cad81173d7725a432b",
+        "dest-filename": "pirates-4.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9323,16 +8014,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/plist/-/plist-3.0.2.tgz#74bbf011124b90421c22d15779cee60060ba95bc",
-        "sha512": "312ae4c1905d43a61aa47cbcefff210d4f0c9c8732c412a3785f8c7179ebe40f4cb5f7cf7b04ecec6de1969a1d4f94da7327c8c854da244861dc619c99ab1381",
-        "dest-filename": "plist-3.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/plist/-/plist-3.0.4.tgz#a62df837e3aed2bb3b735899d510c4f186019cbe",
+        "sha512": "92caebf32f7e9d73b1401da8b1536aae0bd7fd740f397694e0140c2a362af0fbda635535f26a3e7ca8014b0ccafa5b92ca29ceb8f69ef79ea5495701c3194032",
+        "dest-filename": "plist-3.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb",
-        "sha512": "daa1da210af654b445a317b69c04b3b15e9e7f8c8e387f858bd1413951fa72a7928149e8cb248f664c732eecddf9160e41346944e034ced4ccab144e2926ff9c",
-        "dest-filename": "pn-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/plur/-/plur-4.0.0.tgz#729aedb08f452645fe8c58ef115bf16b0a73ef84",
+        "sha512": "e1419ec2b620a83170f6f57accd57e00398f01401f24f2ad1af6ff55da50031db95f97f7c57746772384545c2497c1e5fed97bfb16de1ea48433e0f9fd38ab52",
+        "dest-filename": "plur-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9340,13 +8031,6 @@
         "url": "https://registry.yarnpkg.com/pngjs/-/pngjs-6.0.0.tgz#ca9e5d2aa48db0228a52c419c3308e87720da821",
         "sha512": "4d1cf3b85451984a125bfa7529502688e80f728d88ae56a1f9b18509e35f257c71606c12c3b63000e01c77b5f6f0afe6e5b8c158ab02dbd2b2a0c7c76f2a5aca",
         "dest-filename": "pngjs-6.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149",
-        "sha512": "ed68f2fbd1375b02ce10bdf40fe9bc4d24c5eea2495092ce3419f0429d39d7cb22b8cc544146e0670b2c6855fe40a9599231d9730fc8a590adfc7d2caeb9ed4a",
-        "dest-filename": "pnp-webpack-plugin-1.6.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9365,541 +8049,492 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
-        "sha1": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
-        "dest-filename": "posix-character-classes-0.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.0.tgz#39cbf6babf3ded1e4abf37d09d6eda21c644105c",
+        "sha512": "6f883d79a8051aaf53e52597e3e5127d5ca321bde588f9e38471d130fec5301da4155a58c9f12c715d303f779a5e12a5707294badf25b79046a1eca5580fdd05",
+        "dest-filename": "postcss-attribute-case-insensitive-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz#d93e46b504589e94ac7277b0463226c68041a880",
-        "sha512": "725905c64ffda5c75be15927d21007ab7627c41436a740860f5772db88cdfab781724f845b131bc5252a378623eedd30f1cb25f3b2baa7483105ed6eb6426c60",
-        "dest-filename": "postcss-attribute-case-insensitive-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz#bcfc86134df5807f5d3c0eefa191d42136b5e72a",
+        "sha512": "5fd5fdfd6377288bd8f7e84d11152a5fd82772c801036e5769e47e8ec847cf68fcfac6321e4b47c3525d2ae32378ba4692d5e276a0e103b6ffaa6d66ac10e682",
+        "dest-filename": "postcss-browser-comments-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-browser-comments/-/postcss-browser-comments-3.0.0.tgz#1248d2d935fb72053c8e1f61a84a57292d9f65e9",
-        "sha512": "a9f5632dfabb1c57767b41d6e2cd5dbd4f17d3cd0e65d1b8e9f15b2011635bb512ed83c37167d1bdd125bf0309af62c8ea13260feecb9c7d877265d3b3eb8e8a",
-        "dest-filename": "postcss-browser-comments-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-8.2.2.tgz#9706e7399e8ec8b61a47830dcf1f21391af23373",
+        "sha512": "07947451e078ccb26fc4db7515509a0d950b773b0a2cf73a1618c527ec70162abb546e22f5cb9a24bc558cdb44c4d2bca1c9b79f6a38ba75d72e2557d520aac4",
+        "dest-filename": "postcss-calc-8.2.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-7.0.5.tgz#f8a6e99f12e619c2ebc23cf6c486fdc15860933e",
-        "sha512": "d6d287bad6c6b4bb44645e8f4f82528a10877c8565754ef6999f127591c862b88867d7e1f64f5a592a69693f2b1ecc88ddd5fe29247e5be231f41318dc0383ae",
-        "dest-filename": "postcss-calc-7.0.5.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.1.tgz#a25e9e1855e14d04319222a689f120b3240d39e0",
+        "sha512": "eb63812170a3457a5065c14e6085f05c19690155ab624f1e935adc8ef308346e10d9c7f48a9c8df6a4fe0611c0e8799fb464849c542edaa80a3b780cb1c97747",
+        "dest-filename": "postcss-color-functional-notation-4.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz#5efd37a88fbabeb00a2966d1e53d98ced93f74e0",
-        "sha512": "6410110b2a63103a1f5b83fa21d3d54cb8433573d19fc4f6b35cc76d989d5baacf69a66f727092daca18148409acc652c6278f2765c861395c6f6cedaff793da",
-        "dest-filename": "postcss-color-functional-notation-2.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.2.tgz#7a248b006dd47bd83063f662352d31fd982f74ec",
+        "sha512": "832c7c460a9298654ad79e8d01d29cb1f918dca3c61e12aabc74cbde186f785ac1053a20b8a1738728ae9377258c7e8be1f2742aff8910db8f5ecd568a3dbb67",
+        "dest-filename": "postcss-color-hex-alpha-8.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz#532a31eb909f8da898ceffe296fdc1f864be8547",
-        "sha512": "aba06e46700628cfd94697c36ac71994864f8efc2c4727bb50335a96a573decec60f132da8f63af90f3bd6588dc6ca27530f280bad4e1be3d26b2b18a65d5b9f",
-        "dest-filename": "postcss-color-gray-5.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-7.0.2.tgz#5d397039424a58a9ca628762eb0b88a61a66e079",
+        "sha512": "48573731aa1c1da43a937a19685c07f22a3a31dca9914b44cbf797cd7101d6f11094edd2de80dcfc549903c02c4b4e19db9462ad08650e51cb877767ed77b05b",
+        "dest-filename": "postcss-color-rebeccapurple-7.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz#a8d9ca4c39d497c9661e374b9c51899ef0f87388",
-        "sha512": "3c5e060de97cab7924ade55728b0063691ca8a55ec67ac6ebbe98e40c1d61cb3cdca389404eafbe6ca7964a25f9afd4c0aeb39fc359419c2bd866eaa1c49d763",
-        "dest-filename": "postcss-color-hex-alpha-5.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-5.2.3.tgz#da7fb80e81ad80d2867ea9e38672a892add5df15",
+        "sha512": "76b6b8c68023b9bdb085ae9151702069d1c49f6946c5b8fc76b84570818b38c9fdd7812eec390f52eaee8035e0b2dc2db4262426d67ff8f916456769dd41d120",
+        "dest-filename": "postcss-colormin-5.2.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz#816ba145ac11cc3cb6baa905a75a49f903e4d31d",
-        "sha512": "60fe151bec6e7f1695b7357a666844b5cfbf6935c7dddd092e99d87f1a93bf064f6c9856aa9f1b498de77cdccd4452e00785d268103cd8e13856338e2a909d55",
-        "dest-filename": "postcss-color-mod-function-3.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-5.0.2.tgz#879b849dc3677c7d6bc94b6a2c1a3f0808798059",
+        "sha512": "290d38136c9a7667dad4ba979bb5080f05b57edc54fd05999b3e8d2a71e752f2772c461b6dc5fa8b7dbd7ff8a0f969c40721de82e968717ac409a6462e92fc66",
+        "dest-filename": "postcss-convert-values-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz#c7a89be872bb74e45b1e3022bfe5748823e6de77",
-        "sha512": "6807b73a1912eaa25705bab3bd9b61d80bb85772a2791e6c450e29b5bd9bd8ef3082f07748906c746fa3b27d8165b6f07a40c6f274df70234a7127defe5132f2",
-        "dest-filename": "postcss-color-rebeccapurple-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz#1be6aff8be7dc9bf1fe014bde3b71b92bb4552f1",
+        "sha512": "16f3b61b3314693374b757c150b0de22fc6be48bdb0d77086adb7aa6726085cef7ea7a8d82c19aa39353fb9f9654b010893b7a09bdd8526b348e23da5e12fffe",
+        "dest-filename": "postcss-custom-media-8.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-4.0.3.tgz#ae060bce93ed794ac71264f08132d550956bd381",
-        "sha512": "5b240501d0d9a44c50877da3d14d1f7968ac6747663ad3e5e38a989892a4abdc45598de9fb8aa747308778dae47918703c7cfd6d0de6a34ff25646a9972d0c37",
-        "dest-filename": "postcss-colormin-4.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-12.1.2.tgz#066ecdb03779178ad60b8153755e79a2e70d17a9",
+        "sha512": "66f77e93ae8f1c16183e25ed763355c76979e18f64402ecad5e507cc1343f7b456fdac8dc5f68f396fbd34bdebd27b156d7d5ab0f2dd9038f9f395a0d0d04908",
+        "dest-filename": "postcss-custom-properties-12.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz#ca3813ed4da0f812f9d43703584e449ebe189a7f",
-        "sha512": "2a2b1da35cbbeca502d099a7d0e5d4fc238e25bcccf1c226bf0d5916c0600603206f588bdb766cfcb5d17b7afe119a8cdef19829d436609550e5590923ecc425",
-        "dest-filename": "postcss-convert-values-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-custom-selectors/-/postcss-custom-selectors-6.0.0.tgz#022839e41fbf71c47ae6e316cb0e6213012df5ef",
+        "sha512": "ff58b2061cff5bc8d47a98c6caeed5d4e3dc19b73adfab27375c971100a29dbe81c2decac6c894eff6cb425a7c1b0017cc287b7286c1539a1d367ff6cd0591f1",
+        "dest-filename": "postcss-custom-selectors-6.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz#fffd13ffeffad73621be5f387076a28b00294e0c",
-        "sha512": "73db39897d067b5e68d341ca6ee46e4ea36776c2546da5dd88db24b27547f07e2075cfb36cbcebfd46ac3b0346e824c3a4b15e915638ebbd9e59d8a25aed8652",
-        "dest-filename": "postcss-custom-media-7.0.8.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.3.tgz#febfe305e75267913a53bf5094c7679f5cfa9b55",
+        "sha512": "aa23e6f823409605e231fd09e486c10445c0f65fd0e471ac34690bdf39c8c13d991512c663d5367d35296b896a0945d03b168b8a6a5a7077900bcd010f6a9b0f",
+        "dest-filename": "postcss-dir-pseudo-class-6.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz#2d61772d6e92f22f5e0d52602df8fae46fa30d97",
-        "sha512": "9e6fa8d1e2dd62a76727969b009797a7808453573593e781db2302be1833b1db3f7b4ba669b16b37a1e84f2ffc4382b98a5c4445d97f243d4b3b900da1805e30",
-        "dest-filename": "postcss-custom-properties-8.0.11.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz#9eae4b747cf760d31f2447c27f0619d5718901fe",
+        "sha512": "9606413d30ef5ab6c0618d6fe46604bfc7c43bf5a128ebbf86666a98261fae90fa7b20d65b300eb25dab176f65a6fce228ed3619ce46250b65a644e66a4c0e5a",
+        "dest-filename": "postcss-discard-comments-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz#64858c6eb2ecff2fb41d0b28c9dd7b3db4de7fba",
-        "sha512": "0d218386a8a70aa5ea952e11eca1b12f5392c9c77597276e809d64cb88915cf1dd0518a8cf2307addbb41f7a3ba8d382899c324994d4239315d13f108422eefb",
-        "dest-filename": "postcss-custom-selectors-5.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz#68f7cc6458fe6bab2e46c9f55ae52869f680e66d",
+        "sha512": "b2fc7be3b3d61ca386a405d742409ce24fc3b16a3ee9b7392ec56b02cc3e394f886e2ee4945642c97e788236335f84c7f9fdaecd78d1be22c047190cbab0366c",
+        "dest-filename": "postcss-discard-duplicates-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz#6e3a4177d0edb3abcc85fdb6fbb1c26dabaeaba2",
-        "sha512": "de99b8a2af0761631978f258fb900dae23ecdcfd3babe2d6e8501d4e59051f65ea0dd3f81de78960c3b39f41d82e14528c13b77e18aa4b0c14f711142d2acf83",
-        "dest-filename": "postcss-dir-pseudo-class-5.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz#ee136c39e27d5d2ed4da0ee5ed02bc8a9f8bf6d8",
+        "sha512": "bdf53c0b1010e98a4cc55d92bcc70c2321762d7d59cd6a72d25a870ec39d68a28b41540654fd69ce1ac8f4996c3bae6cebab904df91004a043fc0e60a7d49317",
+        "dest-filename": "postcss-discard-empty-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz#1fbabd2c246bff6aaad7997b2b0918f4d7af4033",
-        "sha512": "449bad376e7d8ae45fdc85bb199c8b3394b0e062d3387f059ac5c19eff006ff4dcda4e12478a9b5780cd6f2c98e3e4a3a37eb64b20e65b60d0ee50520a1ae992",
-        "dest-filename": "postcss-discard-comments-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.2.tgz#e6f51d83e66feffcf05ed94c4ad20b814d0aab5f",
+        "sha512": "fb9e812cfe8d49252e5945e3460010ba1a35a79c6cfe15394b0efec6df52dc94a0fbb47af963069c95bb1eb7bfead4ee676c625cc078d8e6e4899276872fcf7b",
+        "dest-filename": "postcss-discard-overridden-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz#3fe133cd3c82282e550fc9b239176a9207b784eb",
-        "sha512": "64d41f47580f3408976618043457c482517dde9722c345b132425e566c3c785f896416cc0fb8e9e82ebb1aa2405d564fd8159b3b3b4a7dbb1d98ca7f93c73aa1",
-        "dest-filename": "postcss-discard-duplicates-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-double-position-gradients/-/postcss-double-position-gradients-3.0.4.tgz#2484b9785ef3ba81b0f03a279c52ec58fc5344c2",
+        "sha512": "ab3face6f84a265b07c3c1e34acf87564d90185751c82ebc286450197de2f867275238568574049825d6eac88e264675822bb475d3f048ee88e897555553e8a2",
+        "dest-filename": "postcss-double-position-gradients-3.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz#c8c951e9f73ed9428019458444a02ad90bb9f765",
-        "sha512": "07d9a24f36f39e10e34df8ef8a97c7a2a6d62b0774323fbf7cbe6cd503b3d3ac2e7e0ba297e5e17a8e17a4e9dce0da8a60108daaa13380fbf668f04824ba31d3",
-        "dest-filename": "postcss-discard-empty-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-env-function/-/postcss-env-function-4.0.4.tgz#4e85359ca4fcdde4ec4b73752a41de818dbe91cc",
+        "sha512": "d25b5a8514cfb57488944645bfbcc8bdd1226fb1cdd196d4431af120a9fc29b891ca100ba3ce7823f0a0814e65c997ba641bd24c9e80976be465e708d8e86779",
+        "dest-filename": "postcss-env-function-4.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz#652aef8a96726f029f5e3e00146ee7a4e755ff57",
-        "sha512": "2186366c40c3ee0d5733520312c513e3ffe21180b10263f9a0348531553f255bd3ee087e9787e68dc88ba868308dd5a940875bd0285ed955f4d1039b4b9f9c4e",
-        "dest-filename": "postcss-discard-overridden-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz#2028e145313074fc9abe276cb7ca14e5401eb49d",
+        "sha512": "d7c7fdbe80726a4edb4e4b51d90803bde825a67f434db0563d4cd239ef60d0de1647fd9e4ade95adc6dfd219aca6f308e98586cb0cfa07d7fb8f3a453492609d",
+        "dest-filename": "postcss-flexbugs-fixes-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz#fc927d52fddc896cb3a2812ebc5df147e110522e",
-        "sha512": "1be9d5f049d0ab6e5f388f021ff07a92b1288465a7179fb703a1fff891293a772ee5d0a7912d5043af9cb7726469ea70d4d195aaa3991fa96aae6db8e2609fb4",
-        "dest-filename": "postcss-double-position-gradients-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-focus-visible/-/postcss-focus-visible-6.0.3.tgz#14635b71a6b9140f488f11f26cbc9965a13f6843",
+        "sha512": "a333ac83e2f553c4beaf14879c9262113e9d34bc800dc3c78446ab861b4223d0c12c638f1bfda2e1d755a05721f4bceb0606fcb8369a448e27ba277638cf3664",
+        "dest-filename": "postcss-focus-visible-6.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-env-function/-/postcss-env-function-2.0.2.tgz#0f3e3d3c57f094a92c2baf4b6241f0b0da5365d7",
-        "sha512": "af069ce01b999484de51b881abad21ff16cbcd7638dea3ac204ae78166b897b32df91692913ed00635d51937011eea729246e51cc0eb045877d3372160f68e53",
-        "dest-filename": "postcss-env-function-2.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-focus-within/-/postcss-focus-within-5.0.3.tgz#0b0bf425f14a646bbfd973b463e2d20d85a3a841",
+        "sha512": "7e4f72dae152ebf2a9a7bfc0f47cfd678ae5150f3eb738017100970054ab5c51806cac7ee1964e9a67c7b988c238c7a03d6a33d299c2e9f3738bc8fb5f2aa9e5",
+        "dest-filename": "postcss-focus-within-5.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz#9218a65249f30897deab1033aced8578562a6690",
-        "sha512": "f528a87da67d096a505b13b0461d5bfebf39283e72ec682fb0db75d39ea4e8e60bbd652e9f47330afa207c9832942db6b894f05b52b36371b3eb9359465be889",
-        "dest-filename": "postcss-flexbugs-fixes-4.2.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz#efd59b4b7ea8bb06127f2d031bfbb7f24d32fa66",
+        "sha512": "d5f9a405a0802c3ef608ad9af62e3af2603ffadafdff5701c5144c5ce51a66a3b8de858f4798a67323e35f0bafecf5db0a27789dd94fe735a189d41555ade198",
+        "dest-filename": "postcss-font-variant-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz#477d107113ade6024b14128317ade2bd1e17046e",
-        "sha512": "6790a4581c34fa27491d257af8181fda97833857ffc78a3ebd7fe9c1c358ad6a5716b49f4e4437250d688ebabdc92faea670253511de83cb84c054e0a2b8c8f2",
-        "dest-filename": "postcss-focus-visible-4.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-gap-properties/-/postcss-gap-properties-3.0.2.tgz#562fbf43a6a721565b3ca0e01008690991d2f726",
+        "sha512": "11a332fe96f1b509ca0ec9db12376a9640a444e4d0673a2570b2a0204fb76fb12e25f272747e797197877e6f8cb487b35d1aa147cd152a06b3b4efef1eaf7817",
+        "dest-filename": "postcss-gap-properties-3.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz#763b8788596cee9b874c999201cdde80659ef680",
-        "sha512": "5b400fba2f2341e04a6c2199b9d5b7ec478c0a30de5712a08987c8204a3c05d8794a907db3176cfc8abc484bb34b44386053a51bb10f16e95b6f1ba3a64ad5db",
-        "dest-filename": "postcss-focus-within-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-image-set-function/-/postcss-image-set-function-4.0.4.tgz#ce91579ab2c1386d412ff5cd5e733c474b1f75ee",
+        "sha512": "065128f604938faea55e344d072be430af5d11d10615745f1a32918bd7e8f2cd3f3f7a0493be1c028a2797fbad88ce7413638f55bfd74aefa55af756e0ab44fd",
+        "dest-filename": "postcss-image-set-function-4.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-font-variant/-/postcss-font-variant-4.0.1.tgz#42d4c0ab30894f60f98b17561eb5c0321f502641",
-        "sha512": "2370034124cdb4b4d377cbb1661b523ab4c243d1b8a9454a3e31e20e4d1b57be504b15e3556889549d952ddb291948bd7db5bd05c8ca26846fc401f5a5c92a98",
-        "dest-filename": "postcss-font-variant-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-4.0.1.tgz#529f735f72c5724a0fb30527df6fb7ac54d7de42",
+        "sha512": "d2e783eeb3ea5fc3e7d712488dacb4019788b83a05f95f95bccb7fb8e9e7fb87b350a85933f36890378fe83c0c372228601cae37ff782109ede4512468de7dc5",
+        "dest-filename": "postcss-initial-4.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz#431c192ab3ed96a3c3d09f2ff615960f902c1715",
-        "sha512": "4194aa0da3205c21ee1d313332c4b629f5433aaed91629274a992b3c963a8e6c5bba050f4ee4b3b3fbee139237cefd16012fb7be1ae5aa18a38a9ae7b907f39a",
-        "dest-filename": "postcss-gap-properties-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.0.tgz#31db79889531b80dc7bc9b0ad283e418dce0ac00",
+        "sha512": "efb404485070817e22ae880654f810e6cd3bbcbbc5a96af6dbca9963ec3a956e7df5c4652bf1e69e58af9e7554c648c79c2bb8275e8f0cc1dc1fe7bed876ef4d",
+        "dest-filename": "postcss-js-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz#28920a2f29945bed4c3198d7df6496d410d3f288",
-        "sha512": "a0f4dc1458a9e4b672f18ff086da3dd4bf717511c258432cdded4c749c6182de23cb65985df8649e0e7d7c7e6a2d74823cdf24e27f78a750b3adf7b920e90a53",
-        "dest-filename": "postcss-image-set-function-3.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-lab-function/-/postcss-lab-function-4.0.3.tgz#633745b324afbcd5881da85fe2cef58b17487536",
+        "sha512": "307e2dca65a679f75943bb951bfe2271f2e3010987ea8d8d458c9587698aa01e115c9a7d3e3b32859c211f8a2e682407be0faa2558f7473780475110a4895764",
+        "dest-filename": "postcss-lab-function-4.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-3.0.2.tgz#f018563694b3c16ae8eaabe3c585ac6319637b2d",
-        "sha512": "ba0036c0aa270b4c5e347822ad1e03dd5587b3625c534f16022d4a14b55c9dbec837cf698480fa42d83644872d59b9efa754ccd813a60ed5fc1862c229d47c60",
-        "dest-filename": "postcss-initial-3.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.1.tgz#2f53a17f2f543d9e63864460af42efdac0d41f87",
+        "sha512": "73ff5761ba086d2114669883d54403d082a251ef27f561d857b6057bb5fb27e6700ac10a9142521568d2f61054d5147d4c747b8cc5ecb7cb318aa3f48e3a369a",
+        "dest-filename": "postcss-load-config-3.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz#bb51a6856cd12289ab4ae20db1e3821ef13d7d2e",
-        "sha512": "c212f2d48799298fb77d876a405b8305ff00bb0faa16e5670a15a39b19bf5211d6a8d1d9c7e07df44c314ef19899406a7b7163c6ce0bd41a194c998fbbabac56",
-        "dest-filename": "postcss-lab-function-2.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-6.2.1.tgz#0895f7346b1702103d30fdc66e4d494a93c008ef",
+        "sha512": "59b6d8a6601a29cbb1fcfeba6d9e346e95ac06e723c7f4d3815573459f7250ef3241f54195a99e27464655a3df1fae21352061eb76be2023f99ea3a9040d30f9",
+        "dest-filename": "postcss-loader-6.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.1.2.tgz#c5ea504f2c4aef33c7359a34de3573772ad7502a",
-        "sha512": "feb0de195eaf314a379b025999e1df103bf09d328aa90d12ece1d48bf909befb71dda5adc961b6ff46569f30adda4784725c0de937f40d24f6bfd9084dd38a63",
-        "dest-filename": "postcss-load-config-2.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-5.0.3.tgz#9934e0fb16af70adbd94217b24d2f315ceb5c2f0",
+        "sha512": "3f935c1d662b89fd2f2bcae03b2fd3f3bbe0d164488f71d2927aefa75c330db8817a80cf566895466928c27d9e4907693ef79ab7f302d5eb2ce6e873645567a9",
+        "dest-filename": "postcss-logical-5.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-3.0.0.tgz#6b97943e47c72d845fa9e03f273773d4e8dd6c2d",
-        "sha512": "70b5a80c46393b01dc0230e7932450cc05dfb368eb2a35e93bf1d015c7396f9bbfafb69ae3bd707660a19b07e7bfbc76bbce3489ab7fc22d254399db4604a450",
-        "dest-filename": "postcss-loader-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz#7140bddec173e2d6d657edbd8554a55794e2a5b5",
+        "sha512": "c8352f15ff50745653b82520d20d2e3521d5949e57d654b30d98cf4856a2096be382cbeef2f115c6d6a13eb2cc8a72031041a7c7a7017ba8aa771e585b3d3cc1",
+        "dest-filename": "postcss-media-minmax-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-3.0.0.tgz#2495d0f8b82e9f262725f75f9401b34e7b45d5b5",
-        "sha512": "d5250a749736bee30e99e22da86b8d682f8df0ccc15855849009d19cba45623d6d1866bb36ac9506e8df46d80d6b681747ee919065220763b956687b13646688",
-        "dest-filename": "postcss-logical-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-5.0.4.tgz#41f4f3270282ea1a145ece078b7679f0cef21c32",
+        "sha512": "da566b3950fe77cd5aa189190e95aeebeddd4c000690229b5790e84619c847b28e50b56b23f47b6dc32386b1fd293472ea28872aa9ad1be9ff30c8f55a6a8717",
+        "dest-filename": "postcss-merge-longhand-5.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz#b75bb6cbc217c8ac49433e12f22048814a4f5ed5",
-        "sha512": "7e8f66a326baab2c6c8db140625f7ba8a3bd832adedeabdb32790e65e67096c5ba5d816cbecd833060e572154b7c077c2c73d90f18afbbffaa5b648c41e4c707",
-        "dest-filename": "postcss-media-minmax-4.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-5.0.4.tgz#a50640fd832380f322bd2861a9b33fbde4219f9b",
+        "sha512": "c8e8fb6d6dcdc65431684441074944635b07e72f91cdebe36dd1f80c126eae328444da649d107214d74d7be57bda2e692192f5db0a0cf6e19d4b9c5b481fa40d",
+        "dest-filename": "postcss-merge-rules-5.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz#62f49a13e4a0ee04e7b98f42bb16062ca2549e24",
-        "sha512": "6a5c7fce6a1e5ef263a7b2f89b110c8e1f25c55943157d60a961f369a41ec3031989584ba38d9310294a69e1db45fe89ee3f3664e75327cd3c46d37464e670bf",
-        "dest-filename": "postcss-merge-longhand-4.0.11.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-5.0.2.tgz#4603e956d85cd0719156e2b3eb68e3cd2f917092",
+        "sha512": "47a30966bcaadbc0b0d009a7ca15eb33b9daa896592e86b5a5a065b48ce1db033bc9be03e394cbbabf9eb9b4d0e230a6654f5219e65d5ac73929c4a8a9331e4e",
+        "dest-filename": "postcss-minify-font-values-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz#362bea4ff5a1f98e4075a713c6cb25aefef9a650",
-        "sha512": "53b7b7af549bbd8cced09af7513ff3281560618ca1033d1a8adbc62183982b908f9a436287e5834ac4b9b6f3eb27c60c41894432fb19222aa69fb1dd15469e11",
-        "dest-filename": "postcss-merge-rules-4.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-5.0.4.tgz#f13146950513f5a201015306914e3c76d10b591d",
+        "sha512": "455c1903b342e11e09efabbc5f44348fe27b22d294580781509f281046569adbf75e8875f6e349689c33369b327508e4e8f92e851acaf98c3031ff9cfbaf0462",
+        "dest-filename": "postcss-minify-gradients-5.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz#cd4c344cce474343fac5d82206ab2cbcb8afd5a6",
-        "sha512": "8fce683ba3a7454f733dfd38f8f66fd4b60860ea6b5a6e8803ace45e4ac95f246f78312e420806eadbe8cbc8abf19c232f12ee19f3640991101bbcda9fe1dbb6",
-        "dest-filename": "postcss-minify-font-values-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-5.0.3.tgz#9f933d37098ef1dcf007e159a47bb2c1cf06989d",
+        "sha512": "358f761548a413ec2b6a56a255ec457798306fba094c80e181335e230f3d8b5626b20b7845688f5dfcf76e0ee10f2e0d2fa81ea5c4e127039836d64efde362ed",
+        "dest-filename": "postcss-minify-params-5.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz#93b29c2ff5099c535eecda56c4aa6e665a663471",
-        "sha512": "a8a3dfc2538d75c7ff02774fd54f1227fbb3209b68c0794c6928a82b379b017486e2226d865582f62496ce741c5f87faea02165f8e11480f38d474c78f7c0af9",
-        "dest-filename": "postcss-minify-gradients-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-5.1.1.tgz#20ae03b411f7fb397451e3d7d85b989f944b871c",
+        "sha512": "4cecea38f5edf753b696e2489da54f8a2be1f746b64882b935fd446bbc8420cff9c3e5c0e411ab6465125bc684c7da49fe8363ed9241863be281288157e6c2d5",
+        "dest-filename": "postcss-minify-selectors-5.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz#6b9cef030c11e35261f95f618c90036d680db874",
-        "sha512": "1bb796cb3131d312f8ff0881049c493b3e3ccc0295d961b78993aa5613deb7ff6079e7e6fcfc79ba8d5fce51eef833a34fe9b43268b3de3910cd51deeb0c405a",
-        "dest-filename": "postcss-minify-params-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d",
+        "sha512": "6dd1e57859cfde46783580e1b869552be08cad0fe9a949bc6f1fe818bf772ba815c22725bd7e71d27efa7d830ab8818ace50013b2d77cecbea8dbd1ff764c45f",
+        "dest-filename": "postcss-modules-extract-imports-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz#e2e5eb40bfee500d0cd9243500f5f8ea4262fbd8",
-        "sha512": "0f94b58958a58d7063f647e5428e18bad5a7266c26f15bc8b14d46797246886f63f02220f73b38be83cc7500d4988c5eb543a1eb456296c3730a20054ceaaede",
-        "dest-filename": "postcss-minify-selectors-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz#ebbb54fae1598eecfdf691a02b3ff3b390a5a51c",
+        "sha512": "b13ee286d986485f72866ea0822907755d219738834d7ee81685edb9559e0ddde11ce6cd91c1d1a3d577ca0eef08063b70e372c490bf5d70a69a21c772f5fb6d",
+        "dest-filename": "postcss-modules-local-by-default-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz#818719a1ae1da325f9832446b01136eeb493cd7e",
-        "sha512": "2da60b0cd4b8486f10e56016a882607473c9ac30ebfcbbfbef9acc04551b8234f3ea3df8954ce70021dc7515aba0fbd700d3f6563ef234ae7bbe9f5e16accb59",
-        "dest-filename": "postcss-modules-extract-imports-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz#9ef3151456d3bbfa120ca44898dfca6f2fa01f06",
+        "sha512": "867722870140db23dab61f28675e4f66abd61a459ff9751f4205066a64b82eaa0fd5a9d02ceb0e270d2fafb27b2302e9a18f5f6ad036aa21941a6b992f422a96",
+        "dest-filename": "postcss-modules-scope-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz#bb14e0cc78279d504dbdcbfd7e0ca28993ffbbb0",
-        "sha512": "7b7c43abe2e8b6219eb329a946528d81a2743c2ce85087691f4763e3b89602e8bf9324e08770a202bd6a3f9e2ea1d989865ea9f6b37a06835c7440d5271f510f",
-        "dest-filename": "postcss-modules-local-by-default-3.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz#d7c5e7e68c3bb3c9b27cbf48ca0bb3ffb4602c9c",
+        "sha512": "443c47900884188efc812da87f2bc2b2eee2c9c46fee8ab0e713169fd88ca11d0dffb99ff43e7479c42a528e4167d661daf1f86c2511fe4b42a9b07d9bcbc98d",
+        "dest-filename": "postcss-modules-values-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz#385cae013cc7743f5a7d7602d1073a89eaae62ee",
-        "sha512": "632120b13311a4d77e1e6c82ec7fe6877cbe31e1567afcbb5757af5612567b098c6e30c721b65b3972020b6cbe9b5c48d5455f213d47316fced381f1caef685d",
-        "dest-filename": "postcss-modules-scope-2.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-5.0.6.tgz#466343f7fc8d3d46af3e7dba3fcd47d052a945bc",
+        "sha512": "acaaa6d8593429b03c56ddc0746374141f4e04e30355a8cc1ba6427ff1a81e0771509e2c045a7403fb8c2119be30951da37dd85c4b63a88cfcbbb0c0a7c07b0c",
+        "dest-filename": "postcss-nested-5.0.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz#5b5000d6ebae29b4255301b4a3a54574423e7f10",
-        "sha512": "d7ffc4e63081ad9f439915fecc2b6642d45257a3d5e36231ec1ce3f466f025c79dbae7fb22a3fc3207935ee4431ce5a3da6d15cd90f9faba05583b94f1142372",
-        "dest-filename": "postcss-modules-values-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-10.1.2.tgz#2e5f811b3d75602ea18a95dd445bde5297145141",
+        "sha512": "7491a6826b2fa732a854cb43310406fd3e854aab3a903b540e2ac87e5e0a9e3302898f7f1135fc8dd2b209ddb4b3049101b51891a04a576d29c64cf1a0e5cba9",
+        "dest-filename": "postcss-nesting-10.1.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-7.0.1.tgz#b50ad7b7f0173e5b5e3880c3501344703e04c052",
-        "sha512": "16ba2b3dbd07de7b95ab449f7fb5b6ae77374a621caee542e98c29712fa4ebced5c72c4edf7884d5a9a76bbc07b9157333cbdf898a1f5d20473406774212ef62",
-        "dest-filename": "postcss-nesting-7.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz#121559d1bebc55ac8d24af37f67bd4da9efd91d0",
+        "sha512": "e89e3497a2cd62705d3d293e04767c485f870244b8ab6b707b98e7a1c81dfb15a9cff9b1ff949adf69b75b5000f2e13c5da5cdf9e83cb6b2257eef15f71eb57a",
+        "dest-filename": "postcss-normalize-charset-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz#8b35add3aee83a136b0471e0d59be58a50285dd4",
-        "sha512": "80c5c2aeb95687a1b6ed4d21177bcdbd1df0f08d6cdb038120bbc0f3b88d5da3ef48da39b9900c62c646ed78c251fd5e571b8f7f22f84c9efef921992dcf40de",
-        "dest-filename": "postcss-normalize-charset-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.2.tgz#8b5273c6c7d0a445e6ef226b8a5bb3204a55fb99",
+        "sha512": "4715e824f511d2c8528e430cce01190e318fae05d4558c9603f63041189c6f8f07d7938294fb9a0d1eed62890b025199dad09210d10de56c63831483e66e1c53",
+        "dest-filename": "postcss-normalize-display-values-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz#0dbe04a4ce9063d4667ed2be476bb830c825935a",
-        "sha512": "dc5da372c68c5bbf95b51300a9fff79b870f1613c3dc415180db35f2efa4de54c926555eeddd183cef9b9f0aa8db183c6224690d7248daef00d30a89c4cb10b9",
-        "dest-filename": "postcss-normalize-display-values-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-5.0.2.tgz#799fa494b352a5da183be8f050024af6d92fa29c",
+        "sha512": "b6a821585543a766eda85835818a1bd5eb4f3715cb361dee55e5a0644d8040687a6f617c00ad868f7eafe5587287e00fc08ccd8e6b7a8f067da5304ffbf38cf2",
+        "dest-filename": "postcss-normalize-positions-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz#05f757f84f260437378368a91f8932d4b102917f",
-        "sha512": "0e57f7ffd031a7113e345d5f2716037a0822e56c15df93171859e7a1c70fffda83b45ad302b6740f447e88a720e56b1477c9d460c225f325c30ad72b4fc26b74",
-        "dest-filename": "postcss-normalize-positions-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.2.tgz#fd9bddba3e6fd5f5d95c18dfb42a09ecd563adea",
+        "sha512": "feb2199fc5fd6c1cc2ecabd8e222948575065b73266d7c1f3c5db78c2f704fdc538bb900be08fcb04830c638b1066a0be8c55ae163a0c4dcf684047ac132bcb7",
+        "dest-filename": "postcss-normalize-repeat-style-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz#c4ebbc289f3991a028d44751cbdd11918b17910c",
-        "sha512": "aaf8a075860ca52ba816cdc8b3f7f99c77512c937f21303b86e2280b2aaa10d25ef4fbcf98b84d2ccbbb4138cf76d9d57fa39c6183b9487a27c78f9f6c9135f9",
-        "dest-filename": "postcss-normalize-repeat-style-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-5.0.2.tgz#1b2bbf91526f61266f28abf7f773e4136b2c4bd2",
+        "sha512": "cda235cb3c0bf9afc5908cd458c4281f6e58c026318bdd7b278a589b59d15ed760882767953931e5e473a96102eb81ed45ad3a58227d4c8bada5be86996e2017",
+        "dest-filename": "postcss-normalize-string-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz#cd44c40ab07a0c7a36dc5e99aace1eca4ec2690c",
-        "sha512": "46b111a1df7b0e7c2aab8f56373f2aa3aea9b34b306190d26faacce7b90dd89f9aa3210025f67a6ccc74b31fc5f532045f4c6d84f18299eca26a6fe35e27f478",
-        "dest-filename": "postcss-normalize-string-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.2.tgz#db4f4f49721f47667afd1fdc5edb032f8d9cdb2e",
+        "sha512": "028d0f3fa32862c454d4bc5e5545bbe348a8927bdd21499fafab80037c5695027db3af7f4eea72f2ac21b8a1b7c567e5f8abcb3003fda7659717d730ba4ffb06",
+        "dest-filename": "postcss-normalize-timing-functions-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz#8e009ca2a3949cdaf8ad23e6b6ab99cb5e7d28d9",
-        "sha512": "69cc0963de5e74fefad9efbed34121abd2f8b1908470e3f2687c286853a12305820df8a4e98beab1837172479eeb92472cacee3524a601dc700f60ae775679e0",
-        "dest-filename": "postcss-normalize-timing-functions-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.2.tgz#c4db89a0116066716b9e9fcb6444ce63178f5ced",
+        "sha512": "df2fd5faf8d9d7d1cd7138b37aac2b6d9494b04ebd64c4477e28b22c025bec2ee126d6263381ac6da8f2ee029a82ef7b13cab9ae54bd93c161a2303c7291a15b",
+        "dest-filename": "postcss-normalize-unicode-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz#841bd48fdcf3019ad4baa7493a3d363b52ae1cfb",
-        "sha512": "a1dd7c52adb00989febd9fea08e7aeb6f1e30798e6e7b4e8c5168c78db9fd275951da3fd1ee6b9e90c8c17a7ecff8152527548c340813ec5342b82e704fc18c2",
-        "dest-filename": "postcss-normalize-unicode-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-5.0.4.tgz#3b0322c425e31dd275174d0d5db0e466f50810fb",
+        "sha512": "70d8f74732b6a60410c8da7b773ab476aa54a50ff062d74364cdc37a93e61630a66087dc7ae0fd54801c39dbeb35eb63214eb9835078bb074ffcaadfe8015d5e",
+        "dest-filename": "postcss-normalize-url-5.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz#10e437f86bc7c7e58f7b9652ed878daaa95faae1",
-        "sha512": "a79a15685e3e207c2eed5a4c6a7fd24a99a963170932d906a6961fd156dd1f907a84df1836657224bb98f4598b413cd8ddf6a0e444945070ea33e85e89dd1454",
-        "dest-filename": "postcss-normalize-url-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.2.tgz#92c5eaffe5255b5c43fca0baf19227e607c534db",
+        "sha512": "097071fbd7d59734a06e4d085c0fdd7199fd9578b19d0467767b0f0b986ddc7c654356d587beca4032f519f7c9c752d3cf37da7bc7ed32e96c8d898edb27a0c4",
+        "dest-filename": "postcss-normalize-whitespace-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz#bf1d4070fe4fcea87d1348e825d8cc0c5faa7d82",
-        "sha512": "b4ef10220aec237a7de6bf1fcaa295fae7ca9521e1f61309a800aa6efd97927b9fa840e10ef6e0b9718106ac70f67b10a1759fd2a3aaa69ce2289287303e06b4",
-        "dest-filename": "postcss-normalize-whitespace-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-normalize/-/postcss-normalize-10.0.1.tgz#464692676b52792a06b06880a176279216540dd7",
+        "sha512": "fb9c35f3fac37afe66a8445c1b75b919934c25ad5ea1860d1a8f2007bb44c1aa2cd1a8e4dd95c023898719c353e3b344f999d90f5a44a543852ef96d23099e24",
+        "dest-filename": "postcss-normalize-10.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-normalize/-/postcss-normalize-8.0.1.tgz#90e80a7763d7fdf2da6f2f0f82be832ce4f66776",
-        "sha512": "aedf49312fe6f451c846ba030c119232cc96d5cd1f92f3893f2eb6820c521d495d24eec1d7de53a8532a21ffa56397b3a43718395e23f3a694a77fd76f1cc209",
-        "dest-filename": "postcss-normalize-8.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-5.0.3.tgz#d80a8565f2e21efe8a06abacd60629a783bbcf54",
+        "sha512": "4fda434be3fd6d6785bea8af5dde400b3426ac29878efdd93fe7639fc13551963b88aefda454a6ee2dd66cac3655298599d6cc9bcb10d7638f70da73068dd9db",
+        "dest-filename": "postcss-ordered-values-5.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz#0cf75c820ec7d5c4d280189559e0b571ebac0eee",
-        "sha512": "d9f08e6e1e546a7c6f4b1797aed2ed970553841bc79fa31072ee24b0d4f6b6c695d8583be91d8257df16ef0352957fb9fe9170132683c0a2cba0457bb91c9b03",
-        "dest-filename": "postcss-ordered-values-4.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.2.tgz#b4e9c89728cd1e4918173dfb95936b75f78d4148",
+        "sha512": "a1d04c56de8f4d7ee3384f5436f9a72eb17303da574b8e09779b211461ad48763cd100ae245fb5e0c712cb489abd9820459f4e8fffc2f6f38a4267b1bf210932",
+        "dest-filename": "postcss-overflow-shorthand-3.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz#31ecf350e9c6f6ddc250a78f0c3e111f32dd4c30",
-        "sha512": "68ad1f1dcf4204dc7c8dbccc621b2165c12ff0bb589c12116100f98bbc3f2bfc12f5cdbed0d491e81dce54cbb9cb48411d82dc3068df53e76659834a1f423ce6",
-        "dest-filename": "postcss-overflow-shorthand-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-page-break/-/postcss-page-break-3.0.4.tgz#7fbf741c233621622b68d435babfb70dd8c1ee5f",
+        "sha512": "d491aef280a35572daf6af6b153a3831b79e03914c7b4d3ff42ee5378bdaeb4e9175bf879315ed5ec9840eb22b690d757c6cff5af2966bc80cb822a4ad7a53b1",
+        "dest-filename": "postcss-page-break-3.0.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-page-break/-/postcss-page-break-2.0.0.tgz#add52d0e0a528cabe6afee8b46e2abb277df46bf",
-        "sha512": "b64a534ab2e97cb7c3f47be03a526e8a02ee937f705536db77c44a732f3fba05766cd0545b7c54f8022acb1843ad0af55548f5466c89ac19f5616aea526f7301",
-        "dest-filename": "postcss-page-break-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-place/-/postcss-place-7.0.3.tgz#ca8040dfd937c7769a233a3bd6e66e139cf89e62",
+        "sha512": "b434379be198a0e6abf8aa10823fa9c0f02f187029fd26f2eafac58b2ac42eb30a409e007a32f435c4b49a6dbde8e28a600d92460f62b26fe1953fce2e106b75",
+        "dest-filename": "postcss-place-7.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-place/-/postcss-place-4.0.1.tgz#e9f39d33d2dc584e46ee1db45adb77ca9d1dcc62",
-        "sha512": "65be9bc8248b92044a2ce0e3ff9990ba0cae8fd6ef000c3d2ea2498e0c33e5c62bc867977c565f497a0fd547ef79c70599eab46ffdb1c7071311549c9ea1b106",
-        "dest-filename": "postcss-place-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-preset-env/-/postcss-preset-env-7.2.3.tgz#01b9b6eea0ff16c27a3d514f10105d56363428a6",
+        "sha512": "3a4d0384b7f0adc346ac19fcb0d772d6e66a59193ff4521dd06890dfd5b820ba29e461ed8c9b3c6eed4c63d8ac3f01c89e95443d68dbe0211c11a49b04ba5fc0",
+        "dest-filename": "postcss-preset-env-7.2.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz#c34ddacf8f902383b35ad1e030f178f4cdf118a5",
-        "sha512": "794e3f2b9c73485c14149f214dd4d0ce8d9104b6c356df37419ac0bc8d3b4d42ce926c90967625a707a9fb6c882be2bed0a9593b806f15c95e38209c52dc1c86",
-        "dest-filename": "postcss-preset-env-6.7.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.0.2.tgz#6284c2f970715c78fe992d2fac1130e9991585c9",
+        "sha512": "086df927508e507ece381829c393bed24a0e2d4779378bd418a52a480b887b81a2b8b1d653de8faa9f943c2f102134ddd76cd8005c7bea957ba964ffd008ff4c",
+        "dest-filename": "postcss-pseudo-class-any-link-7.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz#2ed3eed393b3702879dec4a87032b210daeb04d1",
-        "sha512": "9605d6f6c60974baad9b0db7a2d3b3aed6c35e87d475f633366e0f229344df6dbfb30112dd553d5e55c77894b8eb34f6a2714eed5d5015d0f843d2e2663f267b",
-        "dest-filename": "postcss-pseudo-class-any-link-6.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-5.0.2.tgz#fa424ce8aa88a89bc0b6d0f94871b24abe94c048",
+        "sha512": "bff91b00043e4b5579bfd4c9bdb1a457df15d8444f754e97bcc70a323a80958889d8db6c1c694a60b3e359671795a4ca371a2821dec11b17ab68af2a5efccab7",
+        "dest-filename": "postcss-reduce-initial-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz#7fd42ebea5e9c814609639e2c2e84ae270ba48df",
-        "sha512": "80a5a6479694ba54a36f339f0fd0252621c2187e801152da334015f9a4a2a31503775eaa5cfd4f0a1f1dd7f04656fa5d5a7f24fc788aee7e938dea1737517b0c",
-        "dest-filename": "postcss-reduce-initial-4.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.2.tgz#9242758629f9ad4d90312eadbc921259d15bee4d",
+        "sha512": "db91de0de16c8223d2531ebd8c95d99fc234ead3312d0249345e61ee2f60b1483c88fe0a38e27c117f1f8f7b1e7a82eddd22d4d980c3e943e70d854650eec310",
+        "dest-filename": "postcss-reduce-transforms-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz#17efa405eacc6e07be3414a5ca2d1074681d4e29",
-        "sha512": "104562835436409e042e925731947c56de43431f3f9a8f9d196491eef597a9ca1bda040bc901ac8a89d87062804d7bd0ccc3e7e8348dd6f4cdef21718a674802",
-        "dest-filename": "postcss-reduce-transforms-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz#d2df6bed10b477bf9c52fab28c568b4b29ca4319",
+        "sha512": "2a617b4813e9853e203cf70a65ceda0e4c1e1e228410ef1c95afc68dc04af9c90ac6266c948bb70b8182456dc335f2f4a3bc96ee4310bbdc656759174572d7b7",
+        "dest-filename": "postcss-replace-overflow-wrap-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz#61b360ffdaedca84c7c918d2b0f0d0ea559ab01c",
-        "sha512": "d93e617041c0ac34fa5fdfbd75548f41da3b407cc6e1729c9454fcad4e53cc93c337b4484536cef5ce1dad42123957a62e3d3769ecd2b47091d8021cafc5cba7",
-        "dest-filename": "postcss-replace-overflow-wrap-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-selector-not/-/postcss-selector-not-5.0.0.tgz#ac5fc506f7565dd872f82f5314c0f81a05630dc7",
+        "sha512": "ff62b70384c23fda2b3f84cd4bbbb7b467511552aacff13aa57dda1a7ae23c6d2353bf287fcc2c51ca84e1002158453477e5a731217ddc087717ffef52d2be89",
+        "dest-filename": "postcss-selector-not-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-5.0.2.tgz#459dd27df6bc2ba64608824ba39e45dacf5e852d",
-        "sha512": "8c351f08f25b28e001870a5429ca8255b6d78a5a1efd05cc71b27a222a5fdec0c88a11334ea44278c05f45a387c6106e4d8aad012ac8d4a256c73ced654e2a51",
-        "dest-filename": "postcss-safe-parser-5.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz#f023ed7a9ea736cd7ef70342996e8e78645a7914",
+        "sha512": "0f93c6e77776d3d67552171cd2a019e54dede476a01f7731bbe58b676da3b7780b5295cce1e5d77e23b5e238835924f734da285ff13cc0849f3a167d7888c64d",
+        "dest-filename": "postcss-selector-parser-6.0.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz#71c8248f917ba2cc93037c9637ee09c64436fcff",
-        "sha512": "2e0b07c1047f12c4584aa970746cde68f2954f4325ecb013e84ef94fc5bcc4b258eb6084e12fe5d3705622dde34fc4daab6da45cfd3cb3649f4d2cdaadaa0fc3",
-        "dest-filename": "postcss-selector-matches-4.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-5.0.3.tgz#d945185756e5dfaae07f9edb0d3cae7ff79f9b30",
+        "sha512": "e355d9500d70343019ad0dd78164442ff336cd2c3c2c93ef6f96568af96306c510006a0428c626ea8907b138c9c4a608e0cef9450107e0a62510ce7657075754",
+        "dest-filename": "postcss-svgo-5.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-selector-not/-/postcss-selector-not-4.0.1.tgz#263016eef1cf219e0ade9a913780fc1f48204cbf",
-        "sha512": "62896f06022710ae7fefd0be6dd14ccb3a9383aa6462a0dbcd92124ff3c332a6bfa37aad5de9c3d396a9046da32e04f4fc143bedde14d942b5da35a98a5a8c01",
-        "dest-filename": "postcss-selector-not-4.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-5.0.2.tgz#5d6893daf534ae52626708e0d62250890108c0c1",
+        "sha512": "c37cc1565aed666ee5a105913d50b4ca3530c29b72ece33a0e71079317124173b56cc4b7449f89512e4b14c48364725cbc6b11c216629c2595aa7f0a7a3e040c",
+        "dest-filename": "postcss-unique-selectors-5.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz#b310f5c4c0fdaf76f94902bbaa30db6aa84f5270",
-        "sha512": "87b7c9ff9b96b915723ad90ee39a67b75221e3408495e7b2087ce2a6a0193b67b91f6d20db9638f2e62715489286f638ad958d27f0626ff2953e66a7682b4e84",
-        "dest-filename": "postcss-selector-parser-3.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514",
+        "sha512": "d4d342b3abaeadf9156de5c6e12f09153f6dd7d9b8e480a789ff3358b779a0f499e74427c0c7caf87de3bf8d3c7788f0ffb06db6fe5ac52e48887a0b69534779",
+        "dest-filename": "postcss-value-parser-4.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c",
-        "sha512": "c3eccb13926183a2e2cfcfab40e584030b70932aa97e79ac8a75e35e0e9c63b60838d659b60bc4d2fd8ed2e85006cd2978da26389c1644ab7a2417d375377739",
-        "dest-filename": "postcss-selector-parser-5.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309",
+        "sha512": "ca2a1aca335b1e7eb3d7f072c326f6638b37caf0c079718ecb1a83f8b9d53a29eae8c76677ef925b6c14355cdabf2c87c5debe0f1cd6188ba8b20e8fd518fcb8",
+        "dest-filename": "postcss-7.0.39.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3",
-        "sha512": "82331e5c17a6a72227681aa9a7c80e0e6c19e7659a62c54eb1faf82f894343b9f79dc0fa984cb24a20ed833093f8d602d2699e38bbedb05f226847f4613e9d07",
-        "dest-filename": "postcss-selector-parser-6.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/postcss/-/postcss-8.4.5.tgz#bae665764dfd4c6fcc24dc0fdf7e7aa00cc77f95",
+        "sha512": "8c10dba1633caa96aac2433022da934138858a486cffaece615bdb94515333b32b663b7ac8c29deabda48178b311b4d396369c9b83657489599e16e3afce1062",
+        "dest-filename": "postcss-8.4.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.2.tgz#17b997bc711b333bab143aaed3b8d3d6e3d38258",
-        "sha512": "0bac328e8dd5c059b4420072f85bbb80260e9029a098296084efa98dcc6fadc04ab622add2e085fa1bdb30ed5fcafe413089912bdd1231bf9dc149df6c677e8f",
-        "dest-filename": "postcss-svgo-4.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz#9446911f3289bfd64c6d680f073c03b1f9ee4bac",
-        "sha512": "f896a755aaf22e8f50c198caae6260908e059fc4818113ba597401262eca88054f966c62901e49cdce04bd7313d87d3f9b4463ad5566f6b18d85975d9bff12a6",
-        "dest-filename": "postcss-unique-selectors-4.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281",
-        "sha512": "a48484eba01b564a787c343b54707044d5f30002898f0e15c3b9d623ff90defba5cbb48d7e0617be6ea2e48805ca51c62b9b0fff11c06c1ecde3d392e2058dc9",
-        "dest-filename": "postcss-value-parser-3.3.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb",
-        "sha512": "f7b0d73856d026193bd677b9fccb7a70ebbacb1b127ccd10190ca5d0bdb919c6b8c865841896a283b97b81b097eb6dd5a9304d18b44b6955029cd91c79d95149",
-        "dest-filename": "postcss-value-parser-4.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f",
-        "sha512": "dad2ee06c03a3f8ad84cd2825d81bfef50bb8f5a54ea92b9d37b2e60e9a7e3162b408cd6fa8a43fbb14014db8649d642ff741fcb7df841b78cbbb3046fc80ec6",
-        "dest-filename": "postcss-values-parser-2.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17",
-        "sha512": "b8816d244971268dbd402ef9dc9ce189da0086fa7f7bf1317b391d85f9adf00ca6593ebfe41ed6d569a9a276169079367a0eac38dc93721d00de790c3ee9f749",
-        "dest-filename": "postcss-7.0.21.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24",
-        "sha512": "dd04fc6c125e5ff4b9cca4d38d30888d117721fe1abc04fa92ac5c012953584b401426fd347d0e5313437e065259d3f97c99c16023045a42057d67ae823cd832",
-        "dest-filename": "postcss-7.0.35.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/postcss/-/postcss-8.2.9.tgz#fd95ff37b5cee55c409b3fdd237296ab4096fba3",
-        "sha512": "6fe4e6b882f88c6b421eda0b8be1bf3e2b2e225f5abf1b3c2193129a5001470373e512d45000ab0bec2cf3575ca26cf59d17b39b960f75788c1330442a0627f9",
-        "dest-filename": "postcss-8.2.9.tgz",
+        "url": "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.0.0.tgz#3c5ce3902f1cb9d6de5ae94ca53575e4af0c1574",
+        "sha512": "22f49e9dfdf72bb25c81d74dcf60f9c39db51203bee1a30c8c5b7bdd493d151cd0ecff9064f2aba7ba8fb03c9db12c231addd3e7144d9ccd5b8f5ccc4c3e5f4c",
+        "dest-filename": "prebuild-install-7.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9918,13 +8553,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc",
-        "sha1": "d4f4562b0ce3696e41ac52d0e002e57a635dc6dc",
-        "dest-filename": "prepend-http-1.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897",
         "sha1": "e92434bfa5ea8c19f41cdfd401d741a3c819d897",
         "dest-filename": "prepend-http-2.0.0.tgz",
@@ -9939,9 +8567,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.2.tgz#be89f82d81b1c86ec8fdfbc385045882727f93b6",
-        "sha512": "118e680f39ac5f9c2fbb29c0072ae66343f485ca7e4299c029b26783603630f8d52970b1ac3494933821549e1918f22ff890b8817f1f3d45ac702d11b63b161b",
-        "dest-filename": "pretty-error-2.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/pretty-error/-/pretty-error-4.0.0.tgz#90a703f46dd7234adb46d0f84823e9d1cb8f10d6",
+        "sha512": "02827960c01c5ca6312a1b8919d72fb1ef95a1ceafd51827b11de759c614eeae2deb3d10e93f3ab2fe59abc54845b396585a6f74613cdcbb5d48c35dfba634c7",
+        "dest-filename": "pretty-error-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9953,16 +8581,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8",
-        "sha512": "f7bdddae2259bf1886390e4e36c161385fc3b733cc38cb600b5d640a952b3c631382aa76abfd60c330aaba872b377de2b34559e461475d960c33d97a87aeefd9",
-        "dest-filename": "pretty-ms-7.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.6.tgz#1b784d2f53c68db31797b2348fa39b49e31846b7",
+        "sha512": "35b96cb5e800d72fd1256d95c8c2fedcb969163cf1eb6714aed0482885835c40e48cd7a5780ece77b9ebcdcb3f54b42f01e5780a049886b377f4344df3c422fe",
+        "dest-filename": "pretty-format-27.4.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33",
-        "sha512": "736f4b56ca8e68b6c11ee21bb13c5a284361d4dd84401387696bfb8241cde1d8116f149112a0e70dbb452587693dab92e180a994c48d080050e847a8afaf5b00",
-        "dest-filename": "prismjs-1.23.0.tgz",
+        "url": "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756",
+        "sha512": "5828c91e5d4a1166e7910a26d7e4b37ed6ed5cc290a1ecce098b39ac40aa30dfa33fe6a923b7eda1f972aa282ace8a523b784c85311bd26142940f2592896012",
+        "dest-filename": "prismjs-1.25.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prismjs/-/prismjs-1.26.0.tgz#16881b594828bb6b45296083a8cbab46b0accd47",
+        "sha512": "1d4a07f42e59de32a497752e9c2ca20f98f0934f87cf47c8810da76f05363a8fdc7ae4c040083ea4f5677ddb764c959154b7312a1f62ba860351273c7256f951",
+        "dest-filename": "prismjs-1.26.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -9974,30 +8609,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182",
-        "sha1": "7332300e840161bda3e69a1d1d91a7d4bc16f182",
-        "dest-filename": "process-0.11.10.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
-        "sha1": "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be",
-        "dest-filename": "progress-1.1.8.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8",
         "sha512": "ecf887b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0",
         "dest-filename": "progress-2.0.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3",
-        "sha1": "98472870bf228132fcbdd868129bad12c3c029e3",
-        "dest-filename": "promise-inflight-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10016,23 +8630,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7",
-        "sha512": "6b06402ab937bcde82ae842e9012fe47dd39d5ae11df3099065266fc705fad267c893a588b1dd55f5bd4e26bde88ba62c263894f8c2891317d9ba1d49382aa59",
-        "dest-filename": "prompts-2.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069",
+        "sha512": "37136ffe42e0b8203ba778c4f282f668406cac95a001a901a609a02ba9693d657e5ae3a663aaf6ff36c05673fe4fc6d0940d27cc75d2252256d07abbca5683d9",
+        "dest-filename": "prompts-2.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/prompts/-/prompts-2.4.1.tgz#befd3b1195ba052f9fd2fde8a486c4e82ee77f61",
-        "sha512": "110c9f22e3b684f0ec5f52ff6e56e557e1fb23492786001df367159de0b071d343f41f00b820ee45c047eb221c1b8745ce5394a9b6b342ac068f1e719ac34bb9",
-        "dest-filename": "prompts-2.4.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5",
-        "sha512": "f1042291d1fbfff476beeac8252bad675b261d84dc2e945610e9479f37161e6058ace194cac2b04acac2f3d0428858f709badf27f9d715d25ea4e56b6351821d",
-        "dest-filename": "prop-types-15.7.2.tgz",
+        "url": "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5",
+        "sha512": "a23f3b0a064809dba5528868815011ec08e50b4df6ed4e1e9782fa780bcea827ae74c0d553435384d695f9bf437f87578123f58173139cf7617deff6a831f972",
+        "dest-filename": "prop-types-15.8.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10051,16 +8658,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf",
-        "sha512": "761fdfaef0815664ac0d8cf0ea7f76ea3bfdef881d7619053df88df213ce8b7d166b1db9419c99106bde96e0a0962067aa6b8cf94266044adb014148a036e33b",
-        "dest-filename": "proxy-addr-2.0.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476",
-        "sha1": "d3fc114ba06995a45ec6893f484ceb1d78f5f476",
-        "dest-filename": "prr-1.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025",
+        "sha512": "96542c30b4940d43d3e388ddad4fcedfbaa59e27e2b433fe670ae699972848ac8b2afb59c69c95d27dbf6c3fcde2d040019fe024475953b28cadaa0ad7e5d802",
+        "dest-filename": "proxy-addr-2.0.7.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10068,13 +8668,6 @@
         "url": "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24",
         "sha512": "44874ecf2a1abcafa1035f0e186583a944ec08b86d03b21c67fe8d0ace1f14968704369bfa90c3983201c96151409ab609deebd4ea10c4118a39acedabe86321",
         "dest-filename": "psl-1.8.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0",
-        "sha512": "cd5a5af282994b3e5b4cc4c50a57357d03a7cb2133a65e68ce98b507961cbc1adda213231f6adfb01b725dcb8dbb08ec0c85e6058945d8de45949621476f6df1",
-        "dest-filename": "public-encrypt-4.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10100,20 +8693,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
-        "sha1": "9653a036fb7c1ee42342f2325cceefea3926c48d",
-        "dest-filename": "punycode-1.3.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e",
-        "sha1": "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e",
-        "dest-filename": "punycode-1.4.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec",
         "sha512": "5d1b118dd7fe8f99a5fb2ffa18a1cf65bac5ffca766206b424fb5da93218d977b9a2124f0fdb1a0c924b3efa7df8d481a6b56f7af7576726e78f672ff0e11dd0",
         "dest-filename": "punycode-2.1.1.tgz",
@@ -10135,51 +8714,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36",
-        "sha512": "3796405f8fcbc49985fbbc0def8a540faa8087dff09ef750723abd4d98debef5f3494a3b6df9b0f75b1aa8c8f3192db1abdd7fa1d376756fd63a5eea40734318",
-        "dest-filename": "qs-6.5.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc",
-        "sha512": "54274144d1535f57f213b35be85628511a3f48f7bad9009a032cc9bd48f045a22c73e35e3c112788796fc459a65f9ebe1d9a61206b55d177828ab06da43ad3c9",
-        "dest-filename": "qs-6.7.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb",
-        "sha1": "bbb693b9ca915c232515b228b1a02b609043dbeb",
-        "dest-filename": "query-string-4.3.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73",
-        "sha1": "9ec61f79049875707d69414596fd907a4d711e73",
-        "dest-filename": "querystring-es3-0.2.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
-        "sha1": "b209849203bb25df820da756e747005878521620",
-        "dest-filename": "querystring-0.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd",
-        "sha512": "c24bd2ee62ff24cba072ea77feb322b4799df5e70819dda584584af4ddd4510e39d21eba775af763d9ef5f34005b52eafb0cb1eb593fd697ca4b92ae2a2c846e",
-        "dest-filename": "querystring-0.2.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6",
-        "sha512": "148aa08f6114bd36bb479d2ed2b1acc937edce3626bff6b784edf8e5b64daea69b36a8ed8220cc826a389a452377e9f3539a05ddd0a52aa1483d42b26d4caaa1",
-        "dest-filename": "querystringify-2.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee",
+        "sha512": "4c8464e1aa982cda0951b77e836944773e642d622e4cc45a8005f197bf10d118958c03ae80799e28d19d777730a3f92da5ff5a2fd7a909f16a58310acac5252d",
+        "dest-filename": "qs-6.9.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10187,6 +8724,20 @@
         "url": "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243",
         "sha512": "36e68d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4",
         "dest-filename": "queue-microtask-1.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f",
+        "sha512": "011842a66ef47f375cbcd41f3e8cb8f4869a9ca913951585d89333aa17096e1485459bfb9cf4ef64975c63bdf4d483e6bd6fbfa744602169d00cb27189fb10ee",
+        "dest-filename": "quick-lru-4.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932",
+        "sha512": "5aec802d18d63c31adb7fc3326269d3b901763ef2167cd215697ba3328af82b691116ef9d57dd26e146f1b778b28e60dfbc544bea2dc7f7c1d9ede386784b848",
+        "dest-filename": "quick-lru-5.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10205,13 +8756,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458",
-        "sha512": "f3b95c6d1f3e321716714890fbd7be470c7c3324763fbaa7b75e729d495b9b74d4fdf8db833e06b2f7d25034de9ad082b550aa6f865c1059723cd4e1f5b0532f",
-        "dest-filename": "randomfill-1.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031",
         "sha512": "1eb82cc7ea2baa8ca09e68456ca68713a736f7a27e1d30105e8c4417a80dba944e9a6189468cb37c6ddc700bdea8206bc2bff6cb143905577f1939796a03b04a",
         "dest-filename": "range-parser-1.2.1.tgz",
@@ -10219,9 +8763,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332",
-        "sha512": "e0ecfc0d423076fa1ae6a3097a5c62a738bf889222e343b9706575c0d629e61bd93fc64dd13fa388d90bd107a95ecf84b10f5727c8a9103a221fbd3249424fdd",
-        "dest-filename": "raw-body-2.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.2.tgz#baf3e9c21eebced59dd6533ac872b71f7b61cb32",
+        "sha512": "44f30015424fd7d5887adffdf67821e88bfc7f301baae9b82e2ec00fa0ed19a5b6469301ff5d710e86a53e224c4dbbba2378646cc564013bd9aea6fd104a9e79",
+        "dest-filename": "raw-body-2.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10233,16 +8777,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz#a0bea50f078b8a082970a9d853dc34b6dcc6a3cf",
-        "sha512": "d2c1789f2f6ffc1eece9aa1e870cdef6f24d59c9827a601460155ab2c715afddbe518884a835cec5f2a35cdebce660da311345dd67611d0b3bea84ce0cca1c14",
-        "dest-filename": "react-app-polyfill-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz#95221e0a9bd259e5ca6b177c7bb1cb6768f68fd7",
+        "sha512": "b19e35731894e65948074d37cb1c50058ac0441a9ed2b7a9a8f4d36014e632a4f3f6ccde05b137ec17a1084f3dd4d66c99d66aa8ffb158a753ddea37bceccdf3",
+        "dest-filename": "react-app-polyfill-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.4.tgz#a7ccb60257a1ca2e0efe7a83e38e6700d17aa37a",
-        "sha512": "771d0bbc818770e3ed29b7a24943388eaa419774dc63b0838d975f38870a7b39c4ec15abf5d83488f1bdd06e727d543ea7fac634c5dd6df4adbf3419115122e0",
-        "dest-filename": "react-dev-utils-11.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-12.0.0.tgz#4eab12cdb95692a077616770b5988f0adf806526",
+        "sha512": "c414248ad771a333f1b75619f4ed74f7b109895a701ebf45a00b84554442295d00bfc341111a2f25abb33fb6e8d5386fba1678b21b10d40262bb8bd0a684f501",
+        "dest-filename": "react-dev-utils-12.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10254,9 +8798,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a",
-        "sha512": "9d04d3714bbe0130dbad20f50591ebe648120f8a05f0e163c6e9fcb8068bf11c0f05a70604d3dfff202e555771d7b37c5cdcd10ccad9f5770a6470a33d6fbd7b",
-        "dest-filename": "react-error-overlay-6.0.9.tgz",
+        "url": "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6",
+        "sha512": "98a47dd1f5fb3e6e6c78239fcfcabd17eeba5427353c6b16481c4a6c84e37ca5501cc345db3b9dc479cc749881d5f4426fe5ec6d057db0ef430a482c31080120",
+        "dest-filename": "react-error-overlay-6.0.10.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10275,16 +8819,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.8.12.tgz#6a9f57277062fb6a6129cad4db5e6198d5c60b58",
-        "sha512": "3363d254ff4ccd3ffbca87d77c2385e60015a2d8a7acce015d68a0ba4f2e152ce726c7c5cd38eba772bd08159c5e2b69a02055646649d809db69619236426a7f",
-        "dest-filename": "react-i18next-11.8.12.tgz",
+        "url": "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.15.3.tgz#7608fb3cacc02ac75a62fc2d68b579f140b198dd",
+        "sha512": "4525043384a8dd3bb624757426c6796237bee27cfae9856231f3d9a32c313b2d31ca7dcbeed136087bc9ed8f4b52cad353bbc6999e5bc1bf0fa639e46ad748c6",
+        "dest-filename": "react-i18next-11.15.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0",
-        "sha512": "ae6cc40c5b7e0155d1cc3ef30c4db581cc72062cc3ff736a8db5fa72656202076a7c9d9488b7abf3ddbbfd0861ad7415edd123ff5106b8e4cfa7b2672d854929",
-        "dest-filename": "react-icons-4.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca",
+        "sha512": "701d743172d3b37815b978a66e501d23bd63ac9c7c9e3ac966634c10c0beb10bb907f0483a696c023b2476aa67f35cbc5015441ae1ce0ddeff722e43be84b34d",
+        "dest-filename": "react-icons-4.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10303,23 +8847,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-lottie-player/-/react-lottie-player-1.3.3.tgz#e44c635718d5cde973d4720fe8359523f0e832ba",
-        "sha512": "55e4ea4db995646ca7d1260fb5c192fa9cb1859c687019fbcf9e9176571a4718c5ea8d36345799e747f44c034e61f1cada0d23b631bea3ce5c6b1a477a292e70",
-        "dest-filename": "react-lottie-player-1.3.3.tgz",
+        "url": "https://registry.yarnpkg.com/react-lottie-player/-/react-lottie-player-1.4.1.tgz#ddd448486b8e8a42f4ae149751c38a8539f80b77",
+        "sha512": "f1dc370edf21ea24c8ac0f88cfb37face6636354a1130a31b20172c16da164f15fe7c9992fbe4d14535763abfde4d363ff6e64650a4c57f6c390da318f849a9e",
+        "dest-filename": "react-lottie-player-1.4.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f",
-        "sha512": "5fc8d91dcee708c8da0aaa14f95d88d1c3a1356f90301c125247979d38bc20f7bacda4567e7eb4673bc50d9a963df99225f8ee6fb7435b548fd2368758bbbf86",
-        "dest-filename": "react-refresh-0.8.3.tgz",
+        "url": "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046",
+        "sha512": "176eea66bf2e52ac215996e8a2776c3f1f2d9c2dc2b774b1640dd5e56c84bee8d1cb236fd1560f868060d6067cfcc579b6e6d0a7be93af0f254eff61cd105af8",
+        "dest-filename": "react-refresh-0.11.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-scripts/-/react-scripts-4.0.3.tgz#b1cafed7c3fa603e7628ba0f187787964cb5d345",
-        "sha512": "4b978ee2f8d4cd48acbe420f07b8d5b0ab6e1f61e159c0124446161c043514fe47c82bf7c609fec2920b0045a49b2f80fad4cd6d2642961c634f7ab3ea0e0bd4",
-        "dest-filename": "react-scripts-4.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/react-scripts/-/react-scripts-5.0.0.tgz#6547a6d7f8b64364ef95273767466cc577cb4b60",
+        "sha512": "de2d0bd82c889513b3ee6c444c475f89fe927e187d2dfa738b5d02b5c1acd5e983412b6665f5a325b00832d443d28a5552342e156a87672459f4f3f32821715a",
+        "dest-filename": "react-scripts-5.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10338,9 +8882,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.3.tgz#fffe3286677ac470b963b364916d16374996f3a6",
-        "sha512": "4e7846819297af9a3c6badee61d453cde6fc8a324e81119ed2a8eb13478afe06a3b5dcaa9d23ba2ea077bd6d7a84707470589ead84a8cbf00e270f33d43ba2f2",
-        "dest-filename": "react-syntax-highlighter-15.4.3.tgz",
+        "url": "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz#db900d411d32a65c8e90c39cd64555bf463e712e",
+        "sha512": "442f742904f167f6fbfbd884eacf679a214b1635acc1471f50b8b81b057374554a54c4324a425606e3a62457e3c233150a8d08514b89ad679b34acaf88aa702d",
+        "dest-filename": "react-syntax-highlighter-15.4.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10380,37 +8924,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02",
-        "sha1": "9d63c13276c065918d57f002a57f40a1b643fb02",
-        "dest-filename": "read-pkg-up-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be",
-        "sha1": "6b72a8048984e0c41e79510fd5e9fa99b3b549be",
-        "dest-filename": "read-pkg-up-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507",
         "sha512": "ccad1307b5dde89a422e694b9ae7eaca4184fbf4e539e3c3eaa28294d5bb8470ca161fc9effee0096191ee3a044045b56caab76b7c9465239b3a858b150e2886",
         "dest-filename": "read-pkg-up-7.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
-        "sha1": "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
-        "dest-filename": "read-pkg-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8",
-        "sha1": "8ef1c0623c6a6db0dc6713c4bfac46332b2368f8",
-        "dest-filename": "read-pkg-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10436,16 +8952,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525",
-        "sha512": "d4953ff2af95805672c70ac9f925483ac87e2b2c161a976cdcd4ea8a488aa43319592726018c8a220aa43be011bcd5897d7797475cf1cfb687178bb80b21fabd",
-        "dest-filename": "readdirp-2.2.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e",
-        "sha512": "70c86eedcffcadd8641d75ac63ea2c0617d2cb4262930a472bfe7e8a6a3e2e979ab1317ca2e12b1eb9589304f4fbe9e38b2b83bdcece158e53dee92f67caa615",
-        "dest-filename": "readdirp-3.5.0.tgz",
+        "url": "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7",
+        "sha512": "84e4b4f3da27f1176ea9d6e1bd0e59dfb0341128ecab3eaa9d171f7ec314df8f7916e4dda929beedb849dbd26f20eb010c41276a7e433eef6ddd3a3d55194ccc",
+        "dest-filename": "readdirp-3.6.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10457,16 +8966,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/refractor/-/refractor-3.3.1.tgz#ebbc04b427ea81dc25ad333f7f67a0b5f4f0be3a",
-        "sha512": "bda37a479ea42ccb81b331d25a5c13a5c67c293306e9a502a24e06af16034f6d1420e5f139ce68ea80dcf2d353cd2947de6dac23e12ef49a369157437144d663",
-        "dest-filename": "refractor-3.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f",
+        "sha512": "ead0c0f20f7c59ed337741af55e313f5aac43a74f0f6a334dcbf5c2576828eb8a9d4e3bbeb844304b05fac1e1cc333460e3e4e0398a8ca60bd1a48b381624352",
+        "dest-filename": "redent-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec",
-        "sha512": "17d0e3635bca2e8fed3de3c3c9cb87ddd9fd1f53933c89150fd2b3e0b383bbe1760bbe66823009ef1fe0c32e9971235100092136525238745ef24de9f8af5684",
-        "dest-filename": "regenerate-unicode-properties-8.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/refractor/-/refractor-3.5.0.tgz#334586f352dda4beaf354099b48c2d18e0819aec",
+        "sha512": "4303c97777dead36787123cf8dd3f96ec607332b705989c03791049cbb46be4aa9fc50829c6b01831ae6f44b880e78d40b751cfe4113b6f562edf488542ef80e",
+        "dest-filename": "refractor-3.5.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz#54d09c7115e1f53dc2314a974b32c1c344efe326",
+        "sha512": "dc4d7651e3523df8eb8308e447cd66e49ec0c3f4f9e53bbb9d4c995506022843acfb6764c4463e0e93ed6733b862bbae88f6fb36460b55cc890b8fb309b939a4",
+        "dest-filename": "regenerate-unicode-properties-9.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10478,16 +8994,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
-        "sha512": "320b86f79a228f47c2dd05775117f8576483606261267246aaf20881d10278e0c24fdf304960c027de124ae5696105284dc19420be8be32341ee3d431451d206",
-        "dest-filename": "regenerator-runtime-0.11.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55",
-        "sha512": "6b9e05c6824322bdbba607fb2207901b19aa50d62b715df7f257ffea01f8e7a1d9fcf857fb905cc075c6f5a8c44a6c1ee9644ed2d033454ad198d38d5a092b7b",
-        "dest-filename": "regenerator-runtime-0.13.7.tgz",
+        "url": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52",
+        "sha512": "a77553f9c38483116c45103d5f896423513e936fc2b672ad53881cc7268252b7a294bfefa88e82759df0c55531dd439483e82750e41071123b066488eb9e8c60",
+        "dest-filename": "regenerator-runtime-0.13.9.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10499,13 +9008,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
-        "sha512": "27a4838d4803c508f936eb273ad745c43c0dffe1d6ca447c1842f072d27b99daa1732cb5c44738491147517bf14e9ebad586952808df44b67d702a92ead9f7d8",
-        "dest-filename": "regex-not-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.11.tgz#3b37ec9049e19479806e878cabe7c1ca83ccfe58",
         "sha512": "8db0ff153d3ef4c054d9701996e23bc36381b354418baa7d33cde792865ac905d753d7bc4686edebd15c65cef05387890ff6054e39f525d0a4deb6cc25a8f3f1",
         "dest-filename": "regex-parser-2.2.11.tgz",
@@ -10513,23 +9015,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26",
-        "sha512": "26205d441abdd56958eee449d1db3b47e754d368ba2ca8bcaf706e4213579fe92678b37e11f1e17e3a8c462b35cc9c6796ef3c86aff8771d0fd8e3f700f45338",
-        "dest-filename": "regexp.prototype.flags-1.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.0.tgz#320e3ccb61ebb74daebffd1c09e484ea3c67070b",
+        "sha512": "384f3945a766098649cd880871677642e9bfc09db45b063967a05fbf915e04f538eae3c3d35b37a5ed8b3688b47ad9abf3789bb0589d0b466229798f63952999",
+        "dest-filename": "regexp.prototype.flags-1.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2",
-        "sha512": "64e23377cc95b10400ee3f0609294f197c20e4f7e60359abab424fe271a1879e0b68a377c5d6a2fef1d40eeef8a4ac15f0ec6c78c4bae6ed8d226a2c41c483d1",
-        "dest-filename": "regexpp-3.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2",
+        "sha512": "a6ad9b5a8f66543e379dbb6cdb01afd7b5cb88d2f26be1a4959f246832d5d99d3c8030ac1a99ca9fd04531ea6f5ae1c26f256f63b279a39f8156fa106e69492e",
+        "dest-filename": "regexpp-3.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.1.tgz#2dea5a9a07233298fbf0db91fa9abc4c6e0f8ad6",
-        "sha512": "cb01f6554ada038e03650b912b30119b0e92eba9abe3ca5056f6b82c179185c3a5b49ea1131bd6972e598c52d8a3aef16c8c5be96d6ae1b006b607c4976d337d",
-        "dest-filename": "regexpu-core-4.7.1.tgz",
+        "url": "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.8.0.tgz#e5605ba361b67b1718478501327502f4479a98f0",
+        "sha512": "d45e9b62ca188b3ea2b3ea33ef4356babd95961f4a5adb30b91bb324e7de614adf3d7da8f27ef802751568e1836d4a9518ef5f347bb8f3fa6324ee2c355c2c3a",
+        "dest-filename": "regexpu-core-4.8.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10555,9 +9057,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.9.tgz#b489eef7c9a2ce43727627011429cf833a7183e6",
-        "sha512": "66a6cd473d523632c0898bb0634ce85d6f0d7baef9217e6af981e2a0019b0b0e17f7a323976f9d717f41d9c89a7b26235620c07ef2231694232602edb5310445",
-        "dest-filename": "regjsparser-0.6.9.tgz",
+        "url": "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.7.0.tgz#a6b667b54c885e18b52554cb4960ef71187e9968",
+        "sha512": "038a5c68e46a98d3035705235a84f3ba1c0c1a93fe3729297ea02c1202351521ff1330bb96b3794cc77e90df180a8bd7fa3329bbc79aa978173c26b483c15035",
+        "dest-filename": "regjsparser-0.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10590,23 +9092,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.5.tgz#483b1ac59c6601ab30a7a596a5965cabccfdd0a5",
-        "sha512": "71caa82e0f872ce1ead6f75f60d9b84c179a083222d452eddf01a88d30d2bdd7b052feb9a13988ddc9d3d84e2146397583329920f2be299ad7ce55182a747ebd",
-        "dest-filename": "renderkid-2.0.5.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce",
-        "sha512": "6a11aad199d5e66e57b592cc6febcfefa91c00ce6790baa4d25a6a02ea2348a1a042d9f87918b86591a6da8968db32851feb0cb166aa3825b576a0273abbbbda",
-        "dest-filename": "repeat-element-1.1.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637",
-        "sha1": "8dcae470e1c88abc2d600fff4a776286da75e637",
-        "dest-filename": "repeat-string-1.6.1.tgz",
+        "url": "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a",
+        "sha512": "abfed521003c966335845fa39feb0548f58694c91201e35870f2e60d0c76cf3ba20df68bace9ae991f226942a57a71608745d13c851e48f947dc0f805b7679a6",
+        "dest-filename": "renderkid-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10614,34 +9102,6 @@
         "url": "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.1.tgz#2d6d996d04a15855d967443631dd5f77825b016a",
         "sha512": "c83e411c27bbaae0a0069878acc43ed0a90844ac160ab1c3397d69d46a7a1f08cf339915a0274a18d84def276aaac5fa949127403299fed14c884750d5dbcf13",
         "dest-filename": "replace-ext-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/request-progress/-/request-progress-2.0.1.tgz#5d36bb57961c673aa5b788dbc8141fdf23b44e08",
-        "sha1": "5d36bb57961c673aa5b788dbc8141fdf23b44e08",
-        "dest-filename": "request-progress-2.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f",
-        "sha512": "4d36c07c10517560fb68d34ea153811f8a4dfca8a057a2f26a960d36500f03c2706e8bd1b62d44f3c9b7b18030b0b8b9af284f2ac13d00fc278c54e07548d3a7",
-        "dest-filename": "request-promise-core-1.1.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28",
-        "sha512": "c1c5beb085225a72a0358d1da82a4e66451b17f23e60f8be7f4f496480dadfd11cfaaf360a94989e20e9f884a04d36ca9a7a4958049e2413d99a8c47f38c2dde",
-        "dest-filename": "request-promise-native-1.0.9.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3",
-        "sha512": "32cbed3ab7c6f5972b3b0016f908be17a1db0f40965c487da2eefbb8e6fb14cd963e1c13eec98cf37dcfcda9e124bb205e337cf48afa5763dccd7367329c0a87",
-        "dest-filename": "request-2.88.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10660,20 +9120,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
-        "sha1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
-        "dest-filename": "require-main-filename-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b",
-        "sha512": "34a37990c0f294aba577160b4947eb6e8e53bb387885dfb613c34f3d7d36999b67d55b911104e861efd9765272f89dee0a97da886174e5eec1f16d225db4079a",
-        "dest-filename": "require-main-filename-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff",
         "sha1": "925d2601d39ac485e091cf0da5c6e694dc3dcaff",
         "dest-filename": "requires-port-1.0.0.tgz",
@@ -10688,23 +9134,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a",
-        "sha1": "00a9f7387556e27038eae232caa372a6a59b665a",
-        "dest-filename": "resolve-cwd-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d",
         "sha512": "3ab65a5f631bfab242a47ffa0a94aab7dc4556937efb1d355e737689ef60e8fe7fdf17a52c0917595003a5dcf52070ff2857c45f213a574534d4e43750edab12",
         "dest-filename": "resolve-cwd-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748",
-        "sha1": "b22c7af7d9d6881bc8b6e653335eebcb0a188748",
-        "dest-filename": "resolve-from-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10730,30 +9162,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz#235e2c28e22e3e432ba7a5d4e305c59a58edfc08",
-        "sha512": "4046f803be9cf0c8bb237c4d2979512904a52c1c23515fd42c530ff86ee7dffeed259f0c1b9c2c677b9cc4fd49cfc55ebe7e9f9c9b310f1f5c225b3ebad1b33d",
-        "dest-filename": "resolve-url-loader-3.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz#d50d4ddc746bb10468443167acf800dcd6c3ad57",
+        "sha512": "d3954431ccd544471bb53ec1cfe0bef7a7943b91c336f76d84888c077e2dec5705f1e85cbb8c02d2c4a03d4b9bb375d6d90dc234b264fc126b094f70551ca688",
+        "dest-filename": "resolve-url-loader-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a",
-        "sha1": "2c637fe77c893afd2a663fe21aa9080068e2052a",
-        "dest-filename": "resolve-url-0.2.1.tgz",
+        "url": "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9",
+        "sha512": "27597e671c69e172b72d40d9f66eb42d1245fe601ee33e9ae31c9a6cf1e4ee9bcae6ddf9740095df68888c90c57966457d994edbdc3a499ebb927474b47cc9b5",
+        "dest-filename": "resolve.exports-1.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130",
-        "sha512": "9437c23da30a7ce2578f2d1d3dacb33dd175a616a6a4d5abdea1428c0bbeaf0fea6d09abe63587e7137687087d40a7f0f44e6fe21c15ec0fa3ac298bf328e3a8",
-        "dest-filename": "resolve-1.18.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975",
-        "sha512": "c043413ede324b3838c9b1505b64d3d73310b9c3caf791d287f9ead82153655386baddbea50bd2b20b5d6b8776e98ad872bd3aef08db9b3386f1bc833c15fadc",
-        "dest-filename": "resolve-1.20.0.tgz",
+        "url": "https://registry.yarnpkg.com/resolve/-/resolve-1.21.0.tgz#b51adc97f3472e6a5cf4444d34bc9d6b9037591f",
+        "sha512": "df009b4e99395899721389923ad0cb86a4261858b4fd30fd54fc268a896793c534c1180c124b6a097777bf2e5bb933b7b658ef6a536f2ab8c711faddd96a4428",
+        "dest-filename": "resolve-1.21.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10772,16 +9197,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
-        "sha512": "4d3958a5af8e2febcc30d1b6e314a5406109dc1fd1cc47d494b72dedbe46ff2b5abfec0fae9942a55305bb0cd76e479c26b6fa218a358856f44bdbf7efbe789a",
-        "dest-filename": "ret-0.1.15.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b",
-        "sha1": "1b42a6266a21f07421d1b0b54b7dc167b01c013b",
-        "dest-filename": "retry-0.12.0.tgz",
+        "url": "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658",
+        "sha512": "5d0050dc8f16d4281ed127a1fba8238f4dcb6e64455aea2cce02bda280a9c1822b861a0ef34a5fab8714914e439249f07ce7c5b5e470959e7a3d838663215676",
+        "dest-filename": "retry-0.13.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10789,34 +9207,6 @@
         "url": "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76",
         "sha512": "53d9c7f3c6b77dcfde902175974fd43f5228b22b888f24e1ee106f5d530762055c7c6bedf3ded782e8f650e2c3788e411b69bbfeec3268b553e9f6ed0b04f2cf",
         "dest-filename": "reusify-1.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/rework-visit/-/rework-visit-1.0.0.tgz#9945b2803f219e2f7aca00adb8bc9f640f842c9a",
-        "sha1": "9945b2803f219e2f7aca00adb8bc9f640f842c9a",
-        "dest-filename": "rework-visit-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/rework/-/rework-1.0.1.tgz#30806a841342b54510aa4110850cd48534144aa7",
-        "sha1": "30806a841342b54510aa4110850cd48534144aa7",
-        "dest-filename": "rework-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1",
-        "sha1": "c0e0d6882df0e23be254a475e8edd41915feaeb1",
-        "dest-filename": "rgb-regex-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3",
-        "sha1": "43374e2e2ca0968b0ef1523460b7d730ff22eeb3",
-        "dest-filename": "rgba-regex-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10835,13 +9225,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c",
-        "sha512": "8a2e226a08b6e56bac568882e01e25abba5b5df029dc3f6fe42c1f918df7bdf7f0dbea640e36350fc19a37bb29b31bc24b1f1d90fa8e642119c9fc5c9891b620",
-        "dest-filename": "ripemd160-2.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/roarr/-/roarr-2.15.4.tgz#f5fe795b7b838ccfe35dc608e0282b9eba2e7afd",
         "sha512": "08784f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
         "dest-filename": "roarr-2.15.4.tgz",
@@ -10849,44 +9232,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz#d15bd259466a9d1accbdb2fe2fff17c52d030acb",
-        "sha512": "2de93f4d8a75fbb83b23eb8c7c99e7489ed85a80f9f1a8e8e8e6ab8657b1ee5bd471ef9108a46e1914a0ced0cedff305fcfb862a650be624c729fdb4f1436ccf",
-        "dest-filename": "rollup-plugin-babel-4.4.0.tgz",
+        "url": "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d",
+        "sha512": "c37888694e0ec5c179d9451789936c35eb9720c0ef16bafe6572ba6c567443ad2ac957eae2e2e9b684b86dbab7a5a1b7c76d7a7909651595fbcede932089a0b9",
+        "dest-filename": "rollup-plugin-terser-7.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz#8c650062c22a8426c64268548957463bf981b413",
-        "sha512": "d6993091eaef309406158bccf67b1cad4a2770fc22291fcaf9b1dd8efe8f160468ddc80f1e8453f37cb601adc6bc8363e39dfd4b5e6dfeda453dbefbe530eceb",
-        "dest-filename": "rollup-plugin-terser-5.3.1.tgz",
+        "url": "https://registry.yarnpkg.com/rollup/-/rollup-2.63.0.tgz#fe2f7fec2133f3fab9e022b9ac245628d817c6bb",
+        "sha512": "9e9b3489d8e60fe35797a39111fc985cc9ff75aaf75867322a7f8a0733dd68b79cb9bdf1fcbac8774c1472d85cafca19500719011f0d29c7c618594d8062f591",
+        "dest-filename": "rollup-2.63.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e",
-        "sha512": "104a7d3619d493063c6a27fa6f1828bcf1cca0ca0daf616e949ce24e7769b791fd45dc02e3b1921ae208f57c6949dcd518cd065ab34f1d5ea27b52d33493da2d",
-        "dest-filename": "rollup-pluginutils-2.8.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4",
-        "sha512": "ff61c0d0473bd13bd09d7773ca715f7e48c0e9737ed5eda912ffee292e5495c6b8d20d8becab8e137ae26ac1e83551ceb050f928a6600ec324d423f74f0f6cf8",
-        "dest-filename": "rollup-1.32.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734",
-        "sha512": "9df30e9404aef4e9d1268d666c4936733d03e7a6b530136b27ba2b8d16501b5d170f2bafc24b0a6ee5cda7aa9afa46e7f37f47c23c2107384599db1a1007dab8",
-        "dest-filename": "rsvp-4.8.5.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.1.tgz#f79781d6a0c510abe73fde60aa3cbe9dfd134a45",
-        "sha512": "1bd375b3feb7dbd16926bf24f5ed54fcb83420359386ff7db1bee4d08ad71e34a7b9bc5ed35879dbf6a3b0f45a7c92b5ff656aae1cf754a2dedc4d5dc7a8d2f5",
-        "dest-filename": "rtl-css-js-1.14.1.tgz",
+        "url": "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.15.0.tgz#680ed816e570a9ebccba9e1cd0f202c6a8bb2dc0",
+        "sha512": "f7d0aee3034d221ac8d74c7151a0011ec743ab36a5ad245389ee0678299b195b9e866e288fe7c8cbc7d3cc1fb5ea998a7bc06ff6b97e8712017b3e8ac44c537b",
+        "dest-filename": "rtl-css-js-1.15.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10894,13 +9256,6 @@
         "url": "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee",
         "sha512": "e65e15c9947ce8b67f943c594d1ea3a8bf00144d92d0814b30fdba01b8ec2d5003c4776107f734194b07fb2dfd51f0a2dddcf3f0e950b8f9a768938ca031d004",
         "dest-filename": "run-parallel-1.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47",
-        "sha1": "e848396f057d223f24386924618e25694161ec47",
-        "dest-filename": "run-queue-1.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10926,23 +9281,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e",
-        "sha1": "40a3669f3b077d1e943d44629e157dd48023bf2e",
-        "dest-filename": "safe-regex-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a",
         "sha512": "619a372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6",
         "dest-filename": "safer-buffer-2.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded",
-        "sha512": "8616f30204c85fc3bb4877e9d9cf3f91111f127e2a3bff6af02f5b7b263afadbd9f3b129a19de2d51204be9dbb601b309cd6d8f6659dea968a56629b0202df64",
-        "dest-filename": "sane-4.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10954,16 +9295,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-10.0.0.tgz#b5cb2547e96d8629a60947544665243b1dc3657a",
-        "sha512": "bd3c6b673e1d5f95bce8cea855655d3957bbd9988fb38d4e8bb67a2a6e16e53babcb3dbc9ab5d2261844059a11b7325622fdfcdf758a5702d20d65a411fba932",
-        "dest-filename": "sanitize.css-10.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-13.0.0.tgz#2675553974b27964c75562ade3bd85d79879f173",
+        "sha512": "651c0a6e1fde43ac3dbe64e392e1b42288b71c1c0f15c7b43bebfffef7be68eab5a1e0b2ee3315daacf3025a6c36eaa9a820638eb88cd656ed65b17f43c8d5c8",
+        "dest-filename": "sanitize.css-13.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.1.1.tgz#4ddd5a3d7638e7949065dd6e9c7c04037f7e663d",
-        "sha512": "5ba8150d701de6147f587b0f89cbd97630161c1704278e146a1831708135f7a7d6da89e0d191cc3ced6466e239ab4565bcc419877da0a6febd3cb5909bbd2aaf",
-        "dest-filename": "sass-loader-10.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/sass-loader/-/sass-loader-12.4.0.tgz#260b0d51a8a373bb8e88efc11f6ba5583fea0bcf",
+        "sha512": "ef137ef24843233ca6d682fd5f24baccfe867acf81a36076c5b3eb8dd307118c95dc041885dff05deaeefbedce0c7174ccc8d899569d6e548aacfae31242fc9a",
+        "dest-filename": "sass-loader-12.4.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -10989,9 +9330,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770",
-        "sha512": "8b6ecc89ce0aa2f33f9671accbcc214421e173b5627096a30234eb620d752bdcdf6579d822de24e45fa4664c239eb84accb89cfc72d4e23d759a3b33d86ffbe6",
-        "dest-filename": "schema-utils-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7",
+        "sha512": "d2294a148e90405e67c4364b167d9d323bdce218e0fd6920eeb1ddde32bafc0e1ad4797d5457505af801d54306a14f78a5a7753fff0dedf31c1272e74a28eef0",
+        "dest-filename": "schema-utils-2.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11003,16 +9344,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef",
-        "sha512": "e83f36ff14b33b4f786a36a7a0e49b7b862f5d631f9f603fffc635f8c52a14026e97906cfb29f7eb16caf4eb4d0dc45548127d8e37a85dfb4ce827f3b6c8ce00",
-        "dest-filename": "schema-utils-3.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281",
+        "sha512": "6393d0c52e084e50be11a84bb97698f3a4d77d1ec3739970dbde1a9573aaf3a2401c28a100865faaff273425af68426f682e75b8df616cb19e57470505d1fe17",
+        "dest-filename": "schema-utils-3.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/screenfull/-/screenfull-5.1.0.tgz#85c13c70f4ead4c1b8a935c70010dfdcd2c0e5c8",
-        "sha512": "75868db8e773afe91ce89e8215c06bce42c27f219c320fa05a427cbacf77210ef2d5c7af85002e805b1a09d3076fa970f0a577c4fcd2c731fbcccd5d41aa7d98",
-        "dest-filename": "screenfull-5.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.0.0.tgz#60331e9e3ae78ec5d16353c467c34b3a0a1d3df7",
+        "sha512": "d5e7725ca821e979c9b09490f262965e737f0556886c530ba68b9152b5e056aed66277b9930dcc5bb50f84ee38b915d0488a53497a096e6ad1d97d30f64513ca",
+        "dest-filename": "schema-utils-4.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba",
+        "sha512": "f416a47ec3b669440dd8af4575b8fced1248119f3643d2068a6ec5a8ce4eb1e6dfa050ba6475e00eafcabe78ae2d33dd78cf30636a3a0e3dd643b29e4028f770",
+        "dest-filename": "screenfull-5.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11031,16 +9379,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d",
-        "sha1": "0e7350acdec80b1108528786ec1d4418d11b396d",
-        "dest-filename": "select-1.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30",
-        "sha512": "d8fe0fb62789784c1581353d4047302110d0fe65c92d7f3ff88deeafe3e0d7a9d2f2835bac6c44b28f4dc985b2f0d0265e2365e1d940a79330a0d7825b338de3",
-        "dest-filename": "selfsigned-1.10.8.tgz",
+        "url": "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.0.0.tgz#e927cd5377cbb0a1075302cff8df1042cc2bce5b",
+        "sha512": "7147458826caa1ad6667aa2cb89b36b831ebb34934a29aec2af7858a268128236add26326f982cd87c614320cd2c298be756594e1aa2e18343a422ba18e3f589",
+        "dest-filename": "selfsigned-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11080,13 +9421,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938",
-        "sha512": "3ab39bdf64de79a99b1fa52b86d4a1985ec2443aa12faff95e93cda760ee447ebef502f0fe8ae1a7bda3f3bbfc41ad5270392faeb04da597037a3022ac999f5d",
-        "dest-filename": "semver-7.3.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7",
         "sha512": "3e878625887c1cae014cefdaf537fa646def7a8fc0ed956c62b480e89f27cbd9dbdc1d55ae992e37ecfd384e707c4e69e87e0b721619b1e8224206c90fde1915",
         "dest-filename": "semver-7.3.5.tgz",
@@ -11094,9 +9428,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8",
-        "sha512": "06c54ab2219c40c1704fc531ca9a1b50acafee2ac23511e4d53d06ebcd2f93cf327fa2c107219c649393242ad33f6c5537ac88f978cf25c36e1375787d3f6c02",
-        "dest-filename": "send-0.17.1.tgz",
+        "url": "https://registry.yarnpkg.com/send/-/send-0.17.2.tgz#926622f76601c41808012c8bf1688fe3906f7820",
+        "sha512": "509601eb0152244dc6d349c48af479ae05a9f1cdb15ef27738f58f866bad794d082a3f2729b1b70eb8e23a62f0a671c6616015c00ebdce64e6fbe606d079b0c3",
+        "dest-filename": "send-0.17.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11115,9 +9449,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4",
-        "sha512": "49a68d6a5f629843bbdfb1f6734e4e834ffc2d45c6ec49ec67231af0cce49ae1e810b7d3eadc6e8f470ca918facdf3ca9e6435c9ab11e0f08973cc7e3382523c",
-        "dest-filename": "serialize-javascript-5.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8",
+        "sha512": "42bdd3a2cbe0b85b7c78f5aab2f45facac905c8896fa719b629cbc5cadb83501c4f3771ac56b7e988ca64d3d7d0c615b35634b7c4c2cae44a637ae2555607d6a",
+        "dest-filename": "serialize-javascript-6.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11129,9 +9463,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9",
-        "sha512": "24caef530139e1e98261695323e846ac6bf923c744c26728ff4d04be4cc822c47b32aac7a276c3f693b630e7c59e9167b65ede72966cfb7996f976d066ef500a",
-        "dest-filename": "serve-static-1.14.1.tgz",
+        "url": "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.2.tgz#722d6294b1d62626d41b43a013ece4598d292bfa",
+        "sha512": "f9330d03d005c54106b82d33da67afa204a79fd31729be1f6bb9e079130969a1aff2f4f09c81242a2f901af3eddf71d29dff29452f9618cd046ccb4224b28c05",
+        "dest-filename": "serve-static-1.14.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11157,13 +9491,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b",
-        "sha512": "2711dcd7078237af30458d1f842a17a722b9e66fd73c769f3a62b85160fb9b6088d7818c705ca9b78c3fd3e355e5ffd931bcb617a4b6c3003b7e0ca787d8164b",
-        "dest-filename": "set-value-2.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285",
         "sha1": "290cbb232e306942d7d7ea9b83732ab7856f8285",
         "dest-filename": "setimmediate-1.0.5.tgz",
@@ -11178,16 +9505,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683",
-        "sha512": "26f74059f6d778819a67d7082e9dfc1e7b594854a8de65a0eb119c249b1df9de1a44c3aa6ae6a0d42eb77497c3c3b39a318c046c730ec4467596a55160fd8e03",
-        "dest-filename": "setprototypeof-1.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7",
-        "sha512": "40c129e41edc7ed13b00f3a393963ac60adb5aef9690b550c24f0936367c9ca45c899681c845ba32e6e2780893a12efe770beb8c6847f23457cf7315774018a9",
-        "dest-filename": "sha.js-2.4.11.tgz",
+        "url": "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424",
+        "sha512": "1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
+        "dest-filename": "setprototypeof-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11195,6 +9515,13 @@
         "url": "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3",
         "sha512": "ffa2aa5fe19551da8fb8f3ddd8bc430f1cd7e8201b8c97a100038a94da6aa94a40a8f33a1de2fc7fea376be26cc868e7da5bf4598f14b1381426353d3a4e7934",
         "dest-filename": "shallow-clone-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sharp/-/sharp-0.29.3.tgz#0da183d626094c974516a48fab9b3e4ba92eb5c2",
+        "sha512": "7ca594b8ec3bec4e27869cb3082251d5acabb6d1e8147053d94fe447fa8431186f3c4725b86e012a3df6e3e4823b57bce3e9275c7c212751c72469d4b7812518",
+        "dest-filename": "sharp-0.29.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11227,16 +9554,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2",
-        "sha512": "991cff9bf255b1c0ab90cc8fa8773f6dcce2dce40790b4ea5c7105bb4cc384afea7efdd470e03849599108b9a8b386e18ebf5e91542e6e3fd1ef068a6a99a242",
-        "dest-filename": "shell-quote-1.7.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b",
-        "sha512": "bc5c1251f42fab26e2202c19639f8301620f2cab163b7d50f752522a5dd462ff8ae5cd9044fce7d2acde73a40fbb541cf5e1d822d88fdcd749a8d56a7ad600c3",
-        "dest-filename": "shellwords-0.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123",
+        "sha512": "5697eac26e049ea19d96c0453661e1c61125258add7dcc4f4e1bbeaf2292e49f0bfdf840c0b6b3159b6af92f93599f40363da989240b1a3e8d420fa528f9b1af",
+        "dest-filename": "shell-quote-1.7.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11248,9 +9568,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c",
-        "sha512": "554278f450bc5353b1c192f121b4d3ac3bcb9dfffa4c383165c2bcc3147ccecd77c69c7bc5b1bad2774196136b162d8432e151a1e0e824eef0b6148bab8d848c",
-        "dest-filename": "signal-exit-3.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af",
+        "sha512": "b03978a8c1698a3706c36d94e70eb72a60f771925f06e16554d6d530a8deda47a828c2fb5f653359b7385eb9846c3c20d0d5c9737cafe3fa31edbf8959be7b91",
+        "dest-filename": "signal-exit-3.0.6.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f",
+        "sha512": "71216d00fb518658efebd20ad214d5650f8e7c4f6778f8bfaed266c395231de57256ba04a895cfd6c173b4a532d6a53ec6fcf7bbfb1f6092daf78edbee700dd9",
+        "dest-filename": "simple-concat-1.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.0.tgz#73fa628278d21de83dadd5512d2cc1f4872bd675",
+        "sha512": "65a95919ec58af74c0d12c324acaf91e580e3a29d2e09b1af18076189ea550d01acf202ee0a1bf566ccc4f002dd98557cf3563f1099e7e60289d920ad8148671",
+        "dest-filename": "simple-get-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11290,23 +9624,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d",
-        "sha512": "3ceab104ae8b6f7abab34e3b0ff5ec0d534f9c5f4397c2526aa7bd87d954465d0e74dab2fee8c3ace8881edb2a5cc19b5964c8a2647300c693c9ac0053ffd17a",
-        "dest-filename": "slice-ansi-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7",
+        "sha512": "ddd3ac0075d7524413a4e61ca00c4b228acc4e9e20210af9216de255bec0ee5148a74547867ca79bd8b3c7a4ecb1dac87152044809558ed9ced8af1b83e0a87b",
+        "dest-filename": "slash-4.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b",
-        "sha512": "a8c08c7e1634e347151d3e372bd045ca0a986d43c564a1ce83b2bbde6b5358945bf29c8fddfcdfe08c5de52cdd10943a311520fd606738bc60859b4a2aeac435",
-        "dest-filename": "slice-ansi-4.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787",
+        "sha512": "a52cafedb4930bb8a0f437206f0f40b913546f993957aa03b9d8d9a0c052af5deaa4b046eed07ece00a40118eaef121481dcf93f541ef2efab486768b8e388c9",
+        "dest-filename": "slice-ansi-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba",
-        "sha512": "895202af13b30b29dffd235a0500b0df878cf6344e53fb39af3221a4ebf3873b981df251fc38597c39178994a02977e0bf6e874f76278b7015fc31b0d1c1a79f",
-        "dest-filename": "smart-buffer-4.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae",
+        "sha512": "f7884ad0787cacfa90976c577371ec681a0e5ca576d0c4e83e4717bf06c84962c4b3eeb8b01ab9905827da42431dbd4faf2f72acfd1dc6b088f5145c8bb4572a",
+        "dest-filename": "smart-buffer-4.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11318,58 +9652,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b",
-        "sha512": "3b6ee5e3168c62dfd1490e53477be9582001e4a6ff73321ca9414e33f0b87d870b9db6547353e48d300c8e87f6a4159a493c0e51deaa5077051951a3eda2309f",
-        "dest-filename": "snapdragon-node-2.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce",
+        "sha512": "18980b4d9eef61bfc9b4f492675d21b0e608bc462c8db354fb33dd20771469654d5043e2bf3c64bb7d7ceb9b124ae7740dad16e2511e38f966c3ddf32d0721b9",
+        "dest-filename": "sockjs-0.3.24.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2",
-        "sha512": "99b2a431d40ab235f80402f86d16138f6d5e74e7fc70ded71dd6142447be667f7d85511870cbca3dcb7522a35eefe0193e2ae7f01083390047419927aa62a565",
-        "dest-filename": "snapdragon-util-3.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8",
+        "sha512": "a415ef402b39ff7ddf74dd7fdfda4f2f4359176d0b7916cb4398ed9e17883cdf494006ae7c68ca75676e667e14ef00ad56ecca8664642340c56076116c1d87d7",
+        "dest-filename": "sortablejs-1.14.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d",
-        "sha512": "16dc8e9d637fc021d355738cc2f4afdba77e928e6f5a52030face8509ecb5bcbe1f99042f107658ef7913fe72b36bb41c22a04516cbfe1d32d6c18c0e22a0d96",
-        "dest-filename": "snapdragon-0.8.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.5.1.tgz#256908f6d5adfb94dabbdbd02c66362cca0f9ea6",
-        "sha512": "5675406faeb77e8b22a48fe6ea9a915da9043b0ee7bdded352076bdcf951ffc57623de5021dc13f0be2733187253c4a60c11d85d4d5338495a28e98a2df63379",
-        "dest-filename": "sockjs-client-1.5.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.21.tgz#b34ffb98e796930b60a0cfa11904d6a339a7d417",
-        "sha512": "0e16cf146a718dce99dc8fae5f4ec877964ed97c18b163ab6236927a27844bbf1cabe25a26f55ee6afe6d6ebe32108578a78487821511fa2605defa6bd53325f",
-        "dest-filename": "sockjs-0.3.21.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad",
-        "sha1": "441b6d4d346798f1b4e49e8920adfba0e543f9ad",
-        "dest-filename": "sort-keys-1.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.13.0.tgz#3ab2473f8c69ca63569e80b1cd1b5669b51269e9",
-        "sha512": "441262acf634b29582ad4e720a658cd5e16cfd7817d89e5ce9bdbbe7f632c454609f33e12a5fd30de53684d47c0edec84eaeba3513cce1494eb7e7b93b80851e",
-        "dest-filename": "sortablejs-1.13.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/sortobject/-/sortobject-4.14.0.tgz#1c1b09862033c93731198a4f7d25eb5140328123",
-        "sha512": "0a91fed6d5e13b620e654eeb969ba80408a5ff5a3171de64608bf029c35dd37ff763d96cf5861eee36c9ea4356ef403fb0a25b3010474f3cbaf083bb288339f2",
-        "dest-filename": "sortobject-4.14.0.tgz",
+        "url": "https://registry.yarnpkg.com/sortobject/-/sortobject-4.16.0.tgz#9f1deca8da47f0d2da0a9100d9b0a407fd9d7b3f",
+        "sha512": "8dd71686a263c7263145c5dadf4a88985dcf65e6b51a937074ac5469cdbc4f6f3e1a8769b47e178a13ee4658026348484c8110567c3c0ed43cd456fa7e89816b",
+        "dest-filename": "sortobject-4.16.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11381,16 +9680,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a",
-        "sha512": "1edcfe467b175a4e7e3f6b25c79261dd0ebabe1423d429659b4cef9da63df3e345c7e0efd8217f7f93bfb7cc7e29a35dadd200b2bb8dce887f2a989a95ba809f",
-        "dest-filename": "source-map-resolve-0.5.3.tgz",
+        "url": "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf",
+        "sha512": "e3e4cdd9bdeda8e09dfe4686449fec4d8034b51d26757c76ea2a5da25c5cc2d255a849ea358be5080b75ab7ca9cb840c958bacf99877e1136d60ba2ada843820",
+        "dest-filename": "source-map-js-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61",
-        "sha512": "5a89e6ef3382209cc1190741fad86c3daaf4918b8223362fc59c2505af3bca2fcc763bfb4e2a7673255b2e3e68d1c14f37811592e4f06f71830f2531d831a71b",
-        "dest-filename": "source-map-support-0.5.19.tgz",
+        "url": "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-3.0.1.tgz#9ae5edc7c2d42570934be4c95d1ccc6352eba52d",
+        "sha512": "569d54b1fc8fbe0ba3290ce2e29c838933a71371381fec87be455137773ff4f266412e02409131bdc0ef697fc3f9157ec506de9fd1c9e7a8cc252dc2814796c8",
+        "dest-filename": "source-map-loader-3.0.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f",
+        "sha512": "b811d4dcbddccec232617297f3c7ddac6a2fc5d482a13183459e92617b524712d95331e0e4fffae87b7aba85251eef4466877e8a75e12a8dea420c17513ff2d7",
+        "dest-filename": "source-map-support-0.5.21.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11426,6 +9732,13 @@
         "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383",
         "sha512": "0a40a3ea088ddd2fa7f6aad88814d7e60cacb6510d9d15b98d978d2c7a5ee9ab9ef92ac7706e55630ba3856f6ce1d637d66106b31043ac747aa08ebd7d35ec69",
         "dest-filename": "source-map-0.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11",
+        "sha512": "db29a0ea8441a5e6de662f5450db2043cf5b871d354dc4e498d4c69cd3bcf2299399b4a0cb89dfba3ae054414a5a9313106035d440e44edee6a8e6d33dd8a020",
+        "dest-filename": "source-map-0.8.0-beta.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11472,9 +9785,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz#e9c18a410e5ed7e12442a549fbd8afa767038d65",
-        "sha512": "53e31310e3b40220f3c7016fa1ae09567315ea666524a936b012edf74b3b1b419dd0c9649dcee4c449f79ee0cf35946d6bb3b6bb2f282dc64b553fb8b2a3591d",
-        "dest-filename": "spdx-license-ids-3.0.7.tgz",
+        "url": "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95",
+        "sha512": "0ad97606b1623345f7300358823dc29328318519abf668bac617a36dd3bdeb49c5e840c90294d8a67d014270ca96734150b2a208dd67df0f440641caf195a0fa",
+        "dest-filename": "spdx-license-ids-3.0.11.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11493,13 +9806,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2",
-        "sha512": "3733558490d8a7071e5558a2f3f1eee8329f0f61be36b407952fd5fea82fefadc462e755c0470c40dc5dda587ed15ad40725cdfe826497982b3a1616bd05188b",
-        "dest-filename": "split-string-3.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c",
         "sha1": "04e6926f662895354f3dd015203633b857297e2c",
         "dest-filename": "sprintf-js-1.0.3.tgz",
@@ -11510,27 +9816,6 @@
         "url": "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673",
         "sha512": "544d123951070a4ed073cba5916c379ed0335eea9fed2da5bf041a0cb46751e20468a35027357a07098b2a13aa4fad5a1a17d432b5de68193ea03182cef85cba",
         "dest-filename": "sprintf-js-1.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877",
-        "sha512": "1d75ea554abbfa970a78baaa663ea61c550cbd7b4e26dd6ea14c74f69156eb4d758a74ccc6a23c040f0f33de66cab232c8ac1d9f38dd1632e213a2813d5b4922",
-        "dest-filename": "sshpk-1.16.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5",
-        "sha512": "71ea5b4aafe77852bbc41e80e74287374c470e8b58ceae7cc1609ae4b796aa73eb1c6f06cdf1233bfe0ef24a667065bea1ac64be110909681b80d938fd957ddd",
-        "dest-filename": "ssri-6.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af",
-        "sha512": "f7ba92873cb5022cb1bcf34890b5a81ae6bbc68433ccf8d0d07007e01d2b58aa3b499e944ae3dcad488016bc2cd141fc46b6d69a0ab72cc4ce6e13c81db6c179",
-        "dest-filename": "ssri-8.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11549,9 +9834,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277",
-        "sha512": "80bfff7e4c5f594b089452f64e5e360a5ebe1c500b11a075154efa23f172fa866346b78fece3cc5c59466f133b350b08d19a547f0efab079efd16358b936fb23",
-        "dest-filename": "stack-utils-2.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5",
+        "sha512": "c6b41c99884eb27ff5917f95adaabeee3e281368ffe8116c719d1eb66620f35c6e33c1aad34db63f16fcf88aa03855086b11ecd0a6926fb4f5f8e7a088dacd14",
+        "dest-filename": "stack-utils-2.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11584,44 +9869,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6",
-        "sha1": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
-        "dest-filename": "static-extend-0.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c",
         "sha1": "161c7dac177659fd9811f43771fa99381478628c",
         "dest-filename": "statuses-1.5.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b",
-        "sha1": "35b09875b4ff49f26a777e509b3090a3226bf24b",
-        "dest-filename": "stealthy-require-1.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b",
-        "sha512": "9d7ea19a4947b3f82bd85bb160396dabc7c90351839712900b3f0efc83386ad46a047f0e3919813607ef5b9806d74193fea43dbb40b322faf65f93e4b7a9edaa",
-        "dest-filename": "stream-browserify-2.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae",
-        "sha512": "be5302d9ff08daefdb646aa475f2d05bfd776628697a3ffb3e64a2310b1b61d771b93b09a7cbd17b6c7616f544c5983b15a39db38dd1380b852703d1e0c4d92f",
-        "dest-filename": "stream-each-1.2.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc",
-        "sha512": "f934a47c83470e8e09f99a1b40b5a2328b90601f9455816db5103de05a44cf327b65da9c2f8b94510ed691d908e034a8cc69a005413f6b8ecbfb7f0f7a75e153",
-        "dest-filename": "stream-http-2.8.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11633,16 +9883,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713",
-        "sha1": "279b225df1d582b1f54e65addd4352e18faa0713",
-        "dest-filename": "strict-uri-encode-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a",
+        "sha512": "fa5eab34de5f607361659cb8d515ec629b428c0d88826ab8106ee4640605408d44d554d76abafa64f5c183a7aaed8e9e2b8144858e80265cae1486ffbff4b455",
+        "dest-filename": "string-length-4.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a",
-        "sha512": "fa5eab34de5f607361659cb8d515ec629b428c0d88826ab8106ee4640605408d44d554d76abafa64f5c183a7aaed8e9e2b8144858e80265cae1486ffbff4b455",
-        "dest-filename": "string-length-4.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/string-length/-/string-length-5.0.1.tgz#3d647f497b6e8e8d41e422f7e0b23bc536c8381e",
+        "sha512": "f44a74f0a00c527d0e69d9d5681b91744da5eb5e42439d3c92bd1731a7630a57d8a5d0b2beb6c5a7a4da79ba3ccb2c68910e2f89477fc4f3d40381468146b4a3",
+        "dest-filename": "string-length-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11668,30 +9918,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e",
-        "sha512": "9cea87e7d75e0aaf52447971ab5030f39267b78c3a2af2caa9656293aa00f599255cb3483a5aa0e05db2ad3d4c55a4e302abd5c1d7de67bc3b682bc90fbba093",
-        "dest-filename": "string-width-2.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010",
+        "sha512": "c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+        "dest-filename": "string-width-4.2.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961",
-        "sha512": "bda7dcbfa2a3559292833d3aa0cfc7e860c1ac0b73f2f76141a9068c522f36b1c0eb2dc7085d422272f2f902eaf1d4c93d0d5bf8a0d4a8315cb647515b8e1ed7",
-        "dest-filename": "string-width-3.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5",
-        "sha512": "5c125b4f737826156e9971347a82d4f430a371a17dd8a2cda939850a71b5a5ff1db94c451b0b4fe800fa9e48f0f5adc876246d2f7136c37243884ff18b7bce78",
-        "dest-filename": "string-width-4.2.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz#608f255e93e072107f5de066f81a2dfb78cf6b29",
-        "sha512": "a649c521655a72135ccaa45f69049ebbf1547e9bc94dee2eb2451267d59cd518a3b0fbb36d9f13c984fc5823679ed0a3504a90def5073007d58f6fb02c08ac3d",
-        "dest-filename": "string.prototype.matchall-4.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz#5abb5dabc94c7b0ea2380f65ba610b3a544b15fa",
+        "sha512": "e968035fc1e642abc477b27e1ba56d01a861b1022cb2267cce5ef32a1d550cc1722f78514c93f8153340dd16c8a764ce43d01834371cededdf1f441bba9f8306",
+        "dest-filename": "string.prototype.matchall-4.0.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11738,30 +9974,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f",
-        "sha1": "a8479022eb1ac368a871389b635262c505ee368f",
-        "dest-filename": "strip-ansi-4.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9",
+        "sha512": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+        "dest-filename": "strip-ansi-6.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae",
-        "sha512": "0ee46cd6029b06ab0c288665adf7f096e83c30791c9e98ece553e62f53c087e980df45340d3a2d7c3674776514b17a4f98f98c309e96efbdcc680dc9fa56e258",
-        "dest-filename": "strip-ansi-5.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
-        "sha512": "02ebca4eb4df40d60d21cb5b4752bf6064d1d7be7a1b270fb20edbf5b755f43baababe20bfa68aa875da87aed9f08992ed6133e5055c3ad95f5b6ad912e82deb",
-        "dest-filename": "strip-ansi-6.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e",
-        "sha1": "6219a85616520491f35788bdbf1447a99c7e6b0e",
-        "dest-filename": "strip-bom-2.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2",
+        "sha512": "717371bd3f1d14d4557e154c1372407bdf269170d83763b597b8e67303273ac9437844a0d6b17f39932d2b49d102189aae2d6e9c6e5c0f88c6deb6a950090b6f",
+        "dest-filename": "strip-ansi-7.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11780,16 +10002,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/strip-comments/-/strip-comments-1.0.2.tgz#82b9c45e7f05873bee53f37168af930aa368679d",
-        "sha512": "90bf7b6a5738ee1a32210495d7ae6d4edf6b1b9767e30d5d367061390ddb394d4d73585e974f639d700d68727bbf31cb77826ef24b1e0c6ce57aff7aa6084b17",
-        "dest-filename": "strip-comments-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf",
-        "sha1": "bb43ff5598a6eb05d89b59fcd129c983313606bf",
-        "dest-filename": "strip-eof-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/strip-comments/-/strip-comments-2.0.1.tgz#4ad11c3fbcac177a67a40ac224ca339ca1c1ba9b",
+        "sha512": "669acac7e6c12d7bf4ebb5930802eff124b3e65dbe5e1a580ac56d4aa94c9e40173160eafbf7a455b975821a8ff6b5074f3bfab26fc3c023a262eb54ff2a757f",
+        "dest-filename": "strip-comments-2.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11797,6 +10012,13 @@
         "url": "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad",
         "sha512": "06ba6f7cd004ddd72fabb965df156e9b38ca8d9439b48d6c11420aaf752892cd17525e394addc595ab55a9e7fda6b9388d10f3856e96660fb76e4f77cbaa4b8c",
         "dest-filename": "strip-final-newline-2.0.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001",
+        "sha512": "95a2536b725bf95429682e83b1e1e117b75756a1d37c93c24436846e277f76b3a1822b60624bbf95eb4c52a397168595d3320851b8e9747dadfad623e1b40c45",
+        "dest-filename": "strip-indent-3.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11815,6 +10037,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db",
+        "sha512": "27c6db37228a5e5e6a61c477e9320ef16de6546547ae69b1b1de4f008b46926cb3c09bf26e2c36215ab99ea7748b82d2352901fecc7d5479656df15dafd93524",
+        "dest-filename": "strnum-1.0.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/strong-data-uri/-/strong-data-uri-1.0.6.tgz#048d501faabaf4c268c608e4b167b06f03ba62b7",
         "sha512": "ce1cc165ebf4ba14f622b1547ab7a75e17da134bc5518c0066c9c6d2020a1a97ccfc68ba8ce510ddc99cbf24ec5de0cb20f893b9b1c449e3bb11b0fa1683e6cf",
         "dest-filename": "strong-data-uri-1.0.6.tgz",
@@ -11822,16 +10051,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.8.tgz#c839157f615c10ba0f4ae35067dad9959eeca346",
-        "sha512": "40b82ffa8897c17802829d8f74f3daf89a69e03f6298af5eff406cc9f78532be902fac0c56aa159fdf8e5d0f48ecc65b994ccdea59a2b53274f6ec12d8e98673",
-        "dest-filename": "strtok3-6.0.8.tgz",
+        "url": "https://registry.yarnpkg.com/strtok3/-/strtok3-6.2.4.tgz#302aea64c0fa25d12a0385069ba66253fdc38a81",
+        "sha512": "18ef0870517d1a6143bea76e22ca540700b309bab37a0c95288b12ca670c82264a7827eb37d4a8c2d5288bcf9be7d5993008c8cd566273f16df7bfa9ca747723",
+        "dest-filename": "strtok3-6.2.4.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e",
-        "sha512": "57b4c2391928f2bb3dac8aa44ab94c7e4a80eb70dfa060412662b590a1827128be0566f872acf4491b27a7897aad4e62c0e11dd3fd9e3efebc495db6557a27e1",
-        "dest-filename": "style-loader-1.3.0.tgz",
+        "url": "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575",
+        "sha512": "18f710f8b0c96eb7311ce45345eb3a272dac7ef2b6912ea1a527c8fdf5e13edfaca55cf117a2c9d5d1cb37dcc81a655a68fd38e1829a21ab456ae7c4351883a1",
+        "dest-filename": "style-loader-3.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11850,16 +10079,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5",
-        "sha512": "ec694b93d270944958e18e9afeb99b1f63215654f25668897753df4c2a8568804418c60db2b3bfbf749e19376105384b83867e35b3a4fea14cc026be27ede9fe",
-        "dest-filename": "stylehacks-4.0.3.tgz",
+        "url": "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.0.1.tgz#323ec554198520986806388c7fdaebc38d2c06fb",
+        "sha512": "12cd2b5671c8a9b5b3bde5356f6e246f0f761ec79b05ea717dca9ee628b1eedf63d0f42a86cd08c57557bf4a58d81c5ad3c0a0324cc3e8e5aa97b91b18eb8474",
+        "dest-filename": "stylehacks-5.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/stylis/-/stylis-4.0.9.tgz#ae3d5283aa439225cf79dd2d0cf46f8bfd4ad393",
-        "sha512": "722ee91053555b7609896133a8f38cb008d8ea482b699dd98017d0e4761b36d2c912c4341b8e9e8d66697d2482a7f15a4a20921868732fd3b694dfb6701ea89e",
-        "dest-filename": "stylis-4.0.9.tgz",
+        "url": "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91",
+        "sha512": "c463d7885565e18103f4987b12ebf6576db49ab886f6ee01d9303a61b8dcd5c6adaecb4a0f63e921d53753444aa645410b612198bfc5d2c3c2afdbeb1533516a",
+        "dest-filename": "stylis-4.0.13.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11878,13 +10107,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3",
-        "sha512": "a9ed637e6d4c83b36afcd4a1e97136e203d744e115b161f10b52c8c7ffd73650fd8b0ed86501a364d8d837bc466841ba88a740f04b4d156e91d208e7557a7ec1",
-        "dest-filename": "supports-color-6.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da",
         "sha512": "aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
         "dest-filename": "supports-color-7.2.0.tgz",
@@ -11899,9 +10121,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47",
-        "sha512": "ce8139fdef9d9c48a393a01207afeaacafa861d9b6768d618e82d6aea502ffc584216d606f115c2ae0687fbb16f00acde9ef8062fb04f070468954562ff17908",
-        "dest-filename": "supports-hyperlinks-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb",
+        "sha512": "eac5c4cd5e7e2398fc066abdfef52984644cfd124d4fd48251124b8f07ce839d61791b60b86583cdc6819600332a141ad0454da4f10acd0b81c19f12f1668279",
+        "dest-filename": "supports-hyperlinks-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09",
+        "sha512": "a2dd169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3",
+        "dest-filename": "supports-preserve-symlinks-flag-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11913,13 +10142,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/svg2png/-/svg2png-4.1.1.tgz#6b9e0398aa418778b6436e127a2fb7f00d499c28",
-        "sha1": "6b9e0398aa418778b6436e127a2fb7f00d499c28",
-        "dest-filename": "svg2png-4.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/svgo/-/svgo-1.3.2.tgz#b6dc511c063346c9e415b81e43401145b96d4167",
         "sha512": "ca1cbfb106314790640bdf0263ba37d551ac834d7800a2c43f175f868adaefa977ea10fd45dcb935903f39c9fac9ac8d3e049a99876d5f6ac525d72fd3b01857",
         "dest-filename": "svgo-1.3.2.tgz",
@@ -11927,16 +10149,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/sweetalert2-react-content/-/sweetalert2-react-content-4.1.0.tgz#754627f3191f4878121d772314559e162c896f22",
-        "sha512": "699a355e62832d728389200c88db60ed8ad516a67a1a2cdb66821cb7eb1fe4bb883ee0357e4035b7b2a7144ef9f7a6899991eb70a8be0578700d9568d0d26209",
-        "dest-filename": "sweetalert2-react-content-4.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24",
+        "sha512": "f8dfd0f64575f85f947966284a250b628e316120d095381bf9ac8ca1b0173f03272efa29ee8c4a328f4ecc8ad7e71dde4b82f87f650785cf5ac57c18f03a4286",
+        "dest-filename": "svgo-2.8.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.0.20.tgz#c0bbd379f6fc929025fc66c08cc8b8f1af76aa9c",
-        "sha512": "86d3559ffec80cd7ea48ba3c9b9d2cd18ec59200239e0ecd9d06ef8b9a757b8c9dc41ca38a2360a568524e182209115833321a484b8e6a6d9de12abd15b5727c",
-        "dest-filename": "sweetalert2-11.0.20.tgz",
+        "url": "https://registry.yarnpkg.com/sweetalert2-react-content/-/sweetalert2-react-content-4.2.0.tgz#ab4a6e02e37150dd0ea34d00179ec76952e3f442",
+        "sha512": "781df6e2cc27ab5d14247f27007d92e861ee00a0e01fa1a9194f2f23eba561d9a53f3a5bd13e503dcecee1114d471dbc1b35595277efb69c596cab59e7f28e9d",
+        "dest-filename": "sweetalert2-react-content-4.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.3.5.tgz#8ba51a3c94506f5c5b60c773bf50aad6ccab04a4",
+        "sha512": "d0d96ac6c32fa13a55acb0fd6d037f68dd8995eb9a5cb2e2043bc6fe46161f38de3a60e9f189fb00439c527c821c37fd8d3ef0ec17b38925fc9a78a383498327",
+        "dest-filename": "sweetalert2-11.3.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11948,9 +10177,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/table/-/table-6.0.9.tgz#790a12bf1e09b87b30e60419bafd6a1fd85536fb",
-        "sha512": "17770bb3d6b784bd59ecde3e1244ac72c7a5df3e795d3f79d00bc1d396f06b2acd8394f5fe0ca45ed8a08a84c08db96dbdb31226fbe11426e77fa997fa7b6725",
-        "dest-filename": "table-6.0.9.tgz",
+        "url": "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.0.13.tgz#0d571643bfc8c76602bbba95a780a9552ae44c64",
+        "sha512": "ada44f185c104865e7ff7874b6d1cd0fd8f23d87ea93fbabd8d5ed950b8adb9f999eb0a3947d6cd63e3fa0fb301c632867318dca4515c9c67f2dc44e6a7504d0",
+        "dest-filename": "tailwindcss-3.0.13.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11962,16 +10191,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621",
-        "sha512": "6a7fca650cd052464292ea0003ae2133dd97d14adbe95a51840165943cf3e3853699c0f9b1c993df305ce15815a64ba0179f34f83427f1e0054b2a10b74b739c",
-        "dest-filename": "tar-6.1.11.tgz",
+        "url": "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0",
+        "sha512": "18dcd0bd04ce20fe91c937c4d90c5bf19565366c349fcf2fa75b33c1646298fd369a74ecc775ad9f9a9176a63dc365ddb8535482f3b084d9d0b23c02a7e92a69",
+        "dest-filename": "tapable-2.2.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d",
-        "sha1": "0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d",
-        "dest-filename": "temp-dir-1.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784",
+        "sha512": "574af663db1c99b0d12c235ec7ffa1633be9ff3c988ef15b1cf36055329f42f56b6fa82e884fdfc4ff976e50cd474d75bada296e47b1da7338747355e860ec9e",
+        "dest-filename": "tar-fs-2.1.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287",
+        "sha512": "ba37aa6dc780060c0c6711099e4d870d8d83967519fbda0471bd4acd355f6078a8d1413a746ef59fad1df03d88e2a36f95e5abad7a668e9b7bbd9785d4b9cc65",
+        "dest-filename": "tar-stream-2.2.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e",
+        "sha512": "6a80409e24269b0b5c2a9ffb073b07f02c73bfc38bef7ea9eefd628466f97bd0c9f644f01961eb42b541e7e95f543cdf1ab751cd7721fa283b2c7698d494ceae",
+        "dest-filename": "temp-dir-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11983,9 +10226,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8",
-        "sha512": "5ab1ffa6e8bc602c267a2028c55fa5a511fd1e946d80185247656204f82919bff09d80f3a76d51e0c378e5fb021af2d13af63aee8ddbca125161138d27222655",
-        "dest-filename": "tempy-0.3.0.tgz",
+        "url": "https://registry.yarnpkg.com/tempy/-/tempy-0.6.0.tgz#65e2c35abc06f1124a97f387b08303442bde59f3",
+        "sha512": "1b5defb4c60f4ff27c0385f64a376d053a61665ae9d602afea16623a3c35e1109683a19b1ee4011ad8e5c7be712db615ff011cd03ec6e4ae2bc4a3ff71793c07",
+        "dest-filename": "tempy-0.6.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -11997,30 +10240,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b",
-        "sha512": "d3845f7b8f7a94df0462bbb08baa0f4241b4be8f02f874f8f57ebcec5667a4f174a8c0081ce348e8711760f283384f1ee478d74f229fa9177f6a01ed1f490eb7",
-        "dest-filename": "terser-webpack-plugin-1.4.5.tgz",
+        "url": "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz#21641326486ecf91d8054161c816e464435bae9f",
+        "sha512": "2cf222b22dce978721c0068f3fcb68509dcbe2a08cd46d306a8ecbdea36fe7b0eb7b3c63ebe544cb24a93f0e01d4748ed8483f84363f30d1795e2842028aa7b1",
+        "dest-filename": "terser-webpack-plugin-5.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-4.2.3.tgz#28daef4a83bd17c1db0297070adc07fc8cfc6a9a",
-        "sha512": "8d3817878d119ef3ab2d0360224c042a743cae61e31cae2efba501122f96f853e6bdbfaea3e7212579ed29eeffde55b998dcac812583eb42b27ac9e15bc0fa31",
-        "dest-filename": "terser-webpack-plugin-4.2.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17",
-        "sha512": "1003e2a5335e5ac6ffdf02cf7aea75b553da5df21a53af3132755d3da7c82f54d5d393a101202b63221f16f9ef24236b4763483af0d534d4c545af917b6316cb",
-        "dest-filename": "terser-4.8.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/terser/-/terser-5.6.1.tgz#a48eeac5300c0a09b36854bf90d9c26fb201973c",
-        "sha512": "caff582c5410fb766a81609493ea6f349c20513765231524d564cdf919da1497b62fb8a91b672c3d3d2b6b65d19bb0acf1cc4ded05e62b5ac5cc4c181109335f",
-        "dest-filename": "terser-5.6.1.tgz",
+        "url": "https://registry.yarnpkg.com/terser/-/terser-5.10.0.tgz#b86390809c0389105eb0a0b62397563096ddafcc",
+        "sha512": "00c985f7d0cc7c40e24497f17d8e638f9c0d1ff6d83b4f5c9e24aa85fa32c5cf2c168608824272f3a1b4e14a195395639699e9955bb42ba4f1e84f5be7e0e51c",
+        "dest-filename": "terser-5.10.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12039,9 +10268,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b",
-        "sha512": "7dcc17e269ddce92d02814b50d5621180718698b7bbec1cd22f415f965ccbe7a30e5c8233e986ae4269ac8b686b2345d48229914d1adeff19802e5da34e89808",
-        "dest-filename": "throat-5.0.0.tgz",
+        "url": "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375",
+        "sha512": "f219a218824c0e5c2383b765278c8a18b2bc12c62a2a03d66c6ddbe308c975d28dc1cecdec3a67d3c0dfe2ccebfec65d31578eb2dadd612b2acd7e8161b701fb",
+        "dest-filename": "throat-6.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12049,13 +10278,6 @@
         "url": "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2",
         "sha512": "1fba0b3d5d0fefe8e0beb93eea6c30c010e6c536b19eef473179a5a0d2d7c2734ed19c59df53ab6a1da7f2553578c3efb1aa303f6097f94482832a2f5df74e15",
         "dest-filename": "throttle-debounce-2.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c",
-        "sha1": "9e785836daf46743145a5984b6268d828528ac6c",
-        "dest-filename": "throttleit-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12095,13 +10317,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.12.tgz#44a45c11fbf407f34f97bccd1577c652361b00ee",
-        "sha512": "f69865efa0aa9ba161497f577b565400c2ed9b504b90a8f641de40a725a45f3b0c45a03b760afcd647f8c099907ff840be0f041322710e8dddbbfd0a9613e229",
-        "dest-filename": "timers-browserify-2.0.12.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4",
         "sha1": "405411a8e7e6339fe64db9a234de11dc31e02bd4",
         "dest-filename": "timsort-0.3.0.tgz",
@@ -12109,16 +10324,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423",
-        "sha512": "341e8393503dc6040f3281aa0b90955e7d76de05b2b5edb5e4e353e4fa796b4cade27944a0ed5959e0b0a6771a7a43c75ceeb48b8ee28459d93e244f8d132ae1",
-        "dest-filename": "tiny-emitter-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875",
-        "sha512": "cadc50beb6f570f73d581108fc749e618a060f49169c610e47c458e8aa2658b05586acf44604f054ef5d2eb1b3edd0be9cdf6597223b38a02046af15ab86414b",
-        "dest-filename": "tiny-invariant-1.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9",
+        "sha512": "d54867fdaab0e42e9123829e8d579383a9884bb22ac672c9f0cbf6b55e6b4dcd2a5a86dacbba43533e968b7f760a773c6a4d47d05d9c8e84736f6fc05b8f85be",
+        "dest-filename": "tiny-invariant-1.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12130,9 +10338,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a",
-        "sha512": "3b208b00a5351f30632fa12fde0c547ab6893656cd8a78268bc22b1c712c607f0b4e612e86f61faaf867d85fe37be9a37f8379f14999f7a38c132d496a7482a4",
-        "dest-filename": "tmp-promise-3.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7",
+        "sha512": "47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1",
+        "dest-filename": "tmp-promise-3.0.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12151,9 +10359,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1",
-        "sha1": "23640dd7b42d00433911140820e5cf440e521dd1",
-        "dest-filename": "tmpl-1.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc",
+        "sha512": "ddfd2e384010c08a86b965b6315cd883c7d5fd036773f229b89346f37eeb2ee73301a2d51ec9561d9423e081a2125e47b379246e1c0bf406fb1ebb26ba3f929b",
+        "dest-filename": "tmpl-1.0.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12165,23 +10373,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43",
-        "sha1": "7d229b1fcc637e466ca081180836a7aabff83f43",
-        "dest-filename": "to-arraybuffer-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e",
         "sha1": "dc5e698cbd079265bc73e0377681a4e4e83f616e",
         "dest-filename": "to-fast-properties-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af",
-        "sha1": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
-        "dest-filename": "to-object-path-0.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12193,23 +10387,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38",
-        "sha1": "7c80c17b9dfebe599e27367e0d4dd5590141db38",
-        "dest-filename": "to-regex-range-2.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4",
         "sha512": "eb93fb8b3e97e7212bd5cc1c82f4316db230ed493780ecb974876d678ac3bde2ea86b7493fe2e2fc7c7ab722b43446fed860b29de08c2621aaac00c248d93cb1",
         "dest-filename": "to-regex-range-5.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
-        "sha512": "156b6578d02d67f2a2daab6a7a3d825d339ac8e1fd6c70d017e438f15a56c835e36d8c40e18cfc883077d735ce05494e1c72a27436ea195ad352f40c3e604607",
-        "dest-filename": "to-regex-3.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12228,16 +10408,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553",
-        "sha512": "c9a387fcf93f5448415964e5848faa5f10c55e57a30c67108a9325cb175af67b61ba56b12d950d714a85c68929d2f7189efb5e2659f914d40346bc63dd871b57",
-        "dest-filename": "toidentifier-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2",
-        "sha512": "9e52ec533826d647cb5d25df45931cd4a2c0ba077886a2470d3bdcda10c8c12de66407cc12e31b734dd2ba3305f8611ca5a5ffa9ba1ec9cc3a88ef09c15bf6fa",
-        "dest-filename": "tough-cookie-2.5.0.tgz",
+        "url": "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35",
+        "sha512": "a39b123ca12483f0c840d987e37574fee7ab2eba7355e764521f2d18dbda797a5fa6ec2329e9e54a8c7fd8efc14e5654b447be246eece58844cfad3c3e500744",
+        "dest-filename": "toidentifier-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12249,16 +10422,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/tr46/-/tr46-2.0.2.tgz#03273586def1595ae08fedb38d7733cee91d2479",
-        "sha512": "de7d6a1beff9920fa3adb4f3c00ca4079c9162d4024ea3862aae54e4f1376f46b5fe6ce8eac9c3863192d3325526e9ced0dad3dc383530bcb94e358ffd4269a6",
-        "dest-filename": "tr46-2.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09",
+        "sha1": "a8b13fd6bfd2489519674ccde55ba3693b706d09",
+        "dest-filename": "tr46-1.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/trash/-/trash-7.1.1.tgz#ef3bc68a8f253c876684972d8a603ef9b4f42b45",
-        "sha512": "886e37bca361e10e78d11adf79f8d2c6597a864a9cdadead00cd407e29175176d6e8eee310a7ed310661a3a760e952d45a783fb96bb86eb1abbc4f5ad2e41b39",
-        "dest-filename": "trash-7.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240",
+        "sha512": "d79221ee985f71d3f9631aa207e883b4ba1a4f3e0d777e7e22202fd2443914d287cd781d5aa3e84c8a840c32665dc790b7825993a9553d3f259c394fa460e9a7",
+        "dest-filename": "tr46-2.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/trash/-/trash-7.2.0.tgz#c5ad0c9b13d7e7cad0b4187b3cfe38cd8b39abe2",
+        "sha512": "ddb47c6796963bc6fdab26d2eac901a1a6af1ff857f4e9dbd51add208849c6ff55a47dda06da5b2ae017e2b221ff4c690d9ecae206b7eb038d93fa246e18d394",
+        "dest-filename": "trash-7.2.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12266,6 +10446,13 @@
         "url": "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc",
         "sha512": "2f43aba62f2a1a9446fff35df87f74bc507ede21e7b9ed734921a634e38287518b27bad4295c15d87be28e9846412d949a15197b04bd560bf1608760afe7c6d4",
         "dest-filename": "tree-kill-1.2.2.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144",
+        "sha512": "7353d3b00ded62b22c2c69099331c5fb0f45d84cb17d71a8e14c89738a452fef853239ead07252ebd4f733b77ffe02ab14ac32e36f5ba2e3deb1c6e379c53e67",
+        "dest-filename": "trim-newlines-3.0.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12298,16 +10485,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92",
-        "sha512": "72c77ebc939bfe0933bdc0878131920a1629cb97f5fd728db26bc118ee095d2fb3d6fd87a1bba00f3e2cd487855ccdf0641e38b9ccecf9e6b307943f71c76143",
-        "dest-filename": "ts-pnp-1.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b",
+        "sha512": "7b969dae73984facea5675aa66eee2fc1437067873bc66e31237a31573b6d252882a9c136aea6408f8047efe0664ad4805c889504858b37277a7be4575a4c556",
+        "dest-filename": "tsconfig-paths-3.12.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b",
-        "sha512": "75172ece891685a8ed656910b0354a6d6c98fa381c2c2e6ca89860d8f4a07f86641f66873ef68e63c6161a19a36faf1be6aa937dab12b033bd93b45488499903",
-        "dest-filename": "tsconfig-paths-3.9.0.tgz",
+        "url": "https://registry.yarnpkg.com/tsd/-/tsd-0.19.1.tgz#c37891ad907d6ce2122e4a20c99cceca5767d713",
+        "sha512": "a52c1c85c96bf800ddc656a145441752b74020e8d7c754f53d057e7cb7d52eea3f4b8cfe4f4d1853ce1f1fc88f959c72036a568098e8e36046d69f520dbe0d3b",
+        "dest-filename": "tsd-0.19.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12319,9 +10506,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a",
-        "sha512": "85c542df0604ce210b186984117b9eec3ef9cdbc0821550c58055b1c8b463f1d338b25f1ace310c78ad0115115e3952dff5228b6e12fc2a3e8a7320e90331fd0",
-        "dest-filename": "tslib-2.1.0.tgz",
+        "url": "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01",
+        "sha512": "efb11bc8f3e9333f8544546e00595632d9a051619ef54386d99db936a0b08888d184e7f988a1aecd27b93f6c3595aabe164472e29f8f0ae5642521a4cd310a57",
+        "dest-filename": "tslib-2.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12329,13 +10516,6 @@
         "url": "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623",
         "sha512": "98728ade25172fedd417ac4be64d0f12129150128f042bfff919043a98d15b1c71dbb28a4419a603ad00f6980e52f322f062a144c3c49a30513f3b365bb3b538",
         "dest-filename": "tsutils-3.21.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6",
-        "sha1": "a157ba402da24e9bf957f9aa69d524eed42901a6",
-        "dest-filename": "tty-browserify-0.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12350,13 +10530,6 @@
         "url": "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c",
         "sha512": "d61fcb9eaf726a3298d8f11b05a74f5e3dd5c6c0c3bbce383a7680a39d9456623322fc30b413c8b8dbe48eecc19535a97c9c946c6ddecf42920626d0923e288e",
         "dest-filename": "tunnel-0.0.6.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64",
-        "sha1": "5ae68177f192d4456269d108afa93ff8743f4f64",
-        "dest-filename": "tweetnacl-0.14.5.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12389,6 +10562,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/type-fest/-/type-fest-0.16.0.tgz#3240b891a78b0deae910dbeb86553e552a148860",
+        "sha512": "79a0731ba331373127f648b0bedadef7471768d2e499a74c59ad7340cb375ce4425cd6ec1ff39ec306f10b989af5d0b12319d302c4b15c969afe9e72f0396f26",
+        "dest-filename": "type-fest-0.16.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f",
+        "sha512": "3880185e4f3e21263ea933b0907b4aab302ec5c8683220fd51dc7e1521900ee89147e3c92891dcd8d2405e56e1906c13b7fe3f9ca67110b635c3745e58e2fc9b",
+        "dest-filename": "type-fest-0.18.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4",
         "sha512": "35ef9e138af4fe25a7a40c43f39db3dc0f8dd01b7944dfff36327045dd95147126af2c317f9bec66587847a962c65e81fb0cfff1dfa669348090dd452242372d",
         "dest-filename": "type-fest-0.20.2.tgz",
@@ -12399,13 +10586,6 @@
         "url": "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37",
         "sha512": "b74af306af3b9b77d571db870d41612a6cb25fef5ea3a5908d9bdfe7511afccd10efe4f7ef8269d5a522c9497418ac69f0cfce113547483be69323e0bd7f97db",
         "dest-filename": "type-fest-0.21.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1",
-        "sha512": "7141899c276be124db78f0a0a8d15ba553427a96be900568849b35b0b871cdd1fe82712839df1585b61aee90f7cd9606894456336c731082377d07118b30e461",
-        "dest-filename": "type-fest-0.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12438,20 +10618,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0",
-        "sha512": "fb99ede400278aab029eed9c11041da73080877de4571f27d15a0589d2a907575554b00dfc5f9b8153aa389a8e9c49eb869db6d9c941e69def5250fed500277e",
-        "dest-filename": "type-1.2.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d",
-        "sha512": "d7cd1630341a20c9b7fbb8465d67f5d86b5d9e20c4cbb9d873214c2899ff799cffead48b5eb50df55d302926cc8de8f423558759ba5110310a1eda8f41af4d37",
-        "dest-filename": "type-2.5.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080",
         "sha512": "cddbbc5cc3440dea4a291f9760e5c054fb56ba2d25cb436da2152c730f9499a1e20164fc86b575aebfff1fa57ed03bc9dce435f52f7bf4cd2568b7d7f2b9bcd9",
         "dest-filename": "typedarray-to-buffer-3.1.5.tgz",
@@ -12466,9 +10632,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.26.tgz#b3731860e241419abd5b542b1a0881070d92e0ce",
-        "sha512": "57022f1a514d9a929b8f346de758e96db153aca2048061f123003c63af4ad41a9ce9b4c857b4da1860013a4821485416b0b99c441e1dac6be97eff73dacceaa1",
-        "dest-filename": "ua-parser-js-0.7.26.tgz",
+        "url": "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6",
+        "sha512": "a8b2bf5def44daece6608dea2de3a6234b443adf93041432508021e1a020534e45558cde66b2947640197c13551916875605744c391d1278094b0fd2c9072191",
+        "dest-filename": "ua-parser-js-0.7.31.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12494,65 +10660,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818",
-        "sha512": "8c3acd9d7587778a07893667c7f646ee0b544d5a7e8027134caafc2f41e3970a6144e116dfe1e29be229bc2fb17091057a06a988c67265ed360b2b8e9d199b9d",
-        "dest-filename": "unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc",
+        "sha512": "c98e4fa4395f548539fb2fc1482c402510484b565cd9d0c6dd48eafac47453e26351ebd6d8986870e17eb2844e60349a01eccecce2aecb28b1843ea60649d299",
+        "dest-filename": "unicode-canonical-property-names-ecmascript-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c",
-        "sha512": "2f8428875e6f4df9edb27e0fd73aa71ee946d0b75782348ed37e5f12976da7a6315e1313e7543abe0339958746ff95f73234be93f63d5f0e1214263d224474ae",
-        "dest-filename": "unicode-match-property-ecmascript-1.0.4.tgz",
+        "url": "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz#54fd16e0ecb167cf04cf1f756bdcc92eba7976c3",
+        "sha512": "e646990ab6e9e6699bcf9ba50640e46d8d12b0f3a32aa552df95692fdba530f7d29742745ec9bef44be986ff42a08645c2b7bb689a1af78018eac78c28654de5",
+        "dest-filename": "unicode-match-property-ecmascript-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz#0d91f600eeeb3096aa962b1d6fc88876e64ea531",
-        "sha512": "c23b901c6415a1f99226fd6e54848a2c4e733b6acd1b333f282619721fd042f7b3ec2d61521048b99ef4d5f617131bae7c914c3e1bf64b22fc0b2a087cc2db21",
-        "dest-filename": "unicode-match-property-value-ecmascript-1.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz#1a01aa57247c14c568b89775a54938788189a714",
+        "sha512": "ed886473461efade0f358cce18a79d0e15db60805ed57110610c4e3f285c5cd309d1608006aaa3e9c93275dea95916531d5e06b823ca74101488c73ad2db0a57",
+        "dest-filename": "unicode-match-property-value-ecmascript-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4",
-        "sha512": "3ea4a83e1fe959eb50da98688f944b89aa88938902370a15dc223e2df1a658b288deb137925d61e7d5e95f6063803ae66f10fd011b50a1b3c65354a0b8262e42",
-        "dest-filename": "unicode-property-aliases-ecmascript-1.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847",
-        "sha512": "b497d79b131e5989dccc256ced7004bc857b89ea6900b7727a958c90793072246966b686ff1c13facd8937cfa9af5fbc8c245ff34145cefafe32941e7a81785e",
-        "dest-filename": "union-value-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff",
-        "sha1": "b31c5ae8254844a3a8281541ce2b04b865a734ff",
-        "dest-filename": "uniq-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02",
-        "sha1": "ffede4b36b25290696e6e165d4a59edb998e6b02",
-        "dest-filename": "uniqs-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230",
-        "sha512": "566a748c8a76967df95135eeaf2be3ce48c6751c9ff5bda54d7b9261488f9b345c977143b58a80c0e9d3264027803f525a19e82730db4cac1a3ab67e493b7135",
-        "dest-filename": "unique-filename-1.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c",
-        "sha512": "ce85abf4e6dac402c3dc338f7e33d2ab1b787e766259b9711c881e5aa5bcc7b52a0f312d1c440bce38b672e258405094e8a9a826290e600665ad31c779b8f1db",
-        "dest-filename": "unique-slug-2.0.2.tgz",
+        "url": "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8",
+        "sha512": "e597eecbdabf0c5af8b5f3bb64f7955dbd5a3e879049d78530ba58b8579b7a10c085bb9ebcbb39cb149998814dd6d3f917d5a5e08a49ad8a2383ce7fce0c991d",
+        "dest-filename": "unicode-property-aliases-ecmascript-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12560,13 +10691,6 @@
         "url": "https://registry.yarnpkg.com/unique-stream/-/unique-stream-2.3.1.tgz#c65d110e9a4adf9a6c5948b28053d9a8d04cbeac",
         "sha512": "da76384e7044ef4ca8c47903962ec331ace95a23fbc4c74262a5369c144ed1407e6691241ac4a28daeccbe6be764551e0be9ab82251f7074abdcb991148838f8",
         "dest-filename": "unique-stream-2.3.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a",
-        "sha1": "9e1057cca851abb93398f8b33ae187b99caec11a",
-        "dest-filename": "unique-string-1.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12606,13 +10730,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
-        "sha1": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
-        "dest-filename": "unset-value-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz#d5324147b104a8aed9ae8639c95521f6f7cda292",
         "sha512": "d3e26252aff3edf689ea889f541e674b0b79f3dbf528276ea8826ea4d543a1649766d5839a30c63b744010ebf0274ef0f746a85e83f87a72ac47b79c32b26d59",
         "dest-filename": "unzip-crx-3-0.2.0.tgz",
@@ -12641,37 +10758,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72",
-        "sha1": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
-        "dest-filename": "urix-0.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2",
-        "sha512": "dc14d5f35dbe0151c738940ef0ee4c916819e5aa2c3fb1a744e270bf32d2f615838f4d2567a674c0d6a4e36dcba7d3c164dd3937e264fcde528bc8d10251b258",
-        "dest-filename": "url-loader-4.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c",
         "sha1": "16b5cafc07dbe3676c1b1999177823d6503acb0c",
         "dest-filename": "url-parse-lax-3.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862",
-        "sha512": "208391c88403f6bbe3d00e022d6b07901049b8da96a4541edb6e1bea3f6dfc0066aae212d2a0d4da963a925e80b8eacbe4e9025c730214d7b58c172e020823bd",
-        "dest-filename": "url-parse-1.5.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1",
-        "sha1": "3838e97cfc60521eb73c525a8e55bfdd9e2e28f1",
-        "dest-filename": "url-0.11.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12683,16 +10772,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/use-trace-update/-/use-trace-update-1.3.0.tgz#27c04a080d8af5df23be7a9579ab5123ea871830",
-        "sha512": "54c84d9e9a0c50a9b75299bbccc7be4e7f6ebee97dc29f6117a445fb488678274d787fa5b7e0a44b2afd400d7c68d805b034b0bc3bba9712770aa96a9f43d825",
-        "dest-filename": "use-trace-update-1.3.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f",
-        "sha512": "73011255794edeeae5f585a5156fd303d72c842121b6eec8289fe9e6ca09fe01a98fbbdbbc5ac063f7888a843a0f0db72a3661620888a3c1ceb359d0dafaffa1",
-        "dest-filename": "use-3.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/use-trace-update/-/use-trace-update-1.3.2.tgz#81d7cb9200d28ccbcd8a8df79735e5905e91f376",
+        "sha512": "890e7fcf522014d4ccfe06068a778d6bf8be4eafde7c36399bb72f7a66bffd8a164f90b4b4fe6b634b6dc2224a6cb88081f7483e9b4c237982735f2255f12ee9",
+        "dest-filename": "use-trace-update-1.3.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12725,30 +10807,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030",
-        "sha512": "8beeaa03630f86fa0a2eec6724da57006860ec7a6140e494ab62ca3190f49b5e448ac91752432f29d17852e8b459878250679afa8d9cc3f66ec1e86d7ecacd90",
-        "dest-filename": "util.promisify-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee",
         "sha512": "83d2690bfdc77b76e6dfccec2eea56af25c7a04712db6607b61b8f41225d332e8a36bcc84735aa72c1f30ff5949ea7b8e70855a2ee1522c3dec37ec3a1758dac",
         "dest-filename": "util.promisify-1.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9",
-        "sha1": "7afb1afe50805246489e3db7fe0ed379336ac0f9",
-        "dest-filename": "util-0.10.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61",
-        "sha512": "1d2840b27cbecd2d9365f697c43f6d623e074069417b35d9319b8cfd2e4f28b2e86644a16621a4f68e42cee908d4b54766f8ddbd9d928f5696fcd767d8d07f1d",
-        "dest-filename": "util-0.11.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12767,13 +10828,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee",
-        "sha512": "1e3483470ea0644e4932081cb4705c8d56a4d3cf8a1158522220f31674fd4bd69e826a7ce52fdb45e0554dbe104c5691369b49f64b9868d8676cd10e91b29bfc",
-        "dest-filename": "uuid-3.4.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
         "sha512": "f8d62cd9078c5b2f865853849bdc679fa1c20e9d25ed0043ee697cccb52627ef77439345d0da1c12b9f09139175453625f7fdfa42e9a7d2f0385bfe0cfb47b7a",
         "dest-filename": "uuid-8.3.2.tgz",
@@ -12788,9 +10842,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz#04bfd1026ba4577de5472df4f5e89af49de5edda",
-        "sha512": "a74041d3d1391518f1d042cde9182eb083ec48f86d81ec5245c2844f26c4b3a2063935c9499a9fc31a7baffff9e679eed1fd40c65b58e55bdd56acb6bd97fd00",
-        "dest-filename": "v8-to-istanbul-7.1.1.tgz",
+        "url": "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz#77b752fd3975e31bbcef938f85e9bd1c7a8d60ed",
+        "sha512": "146b4ab6fdf122947a05886f807f0c23fcbbf284fb77c02edf0c38408c729ab0ad6448796fc802c36b22cb013ea6e8449ae58a0ed99faef179525076f7cbaddf",
+        "dest-filename": "v8-to-istanbul-8.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12816,16 +10870,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e",
-        "sha512": "fe3b86eb99132f80b2dacbb83fc1e3b644f193a56624388e3c1b9f5a78aa43ac249da73a8cd8974bdbd4fa13b7c20bac8b2a969734db5478b477226a44e360df",
-        "dest-filename": "vendors-1.0.4.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400",
-        "sha1": "3a105ca17053af55d6e270c1f8288682e18da400",
-        "dest-filename": "verror-1.10.0.tgz",
+        "url": "https://registry.yarnpkg.com/verror/-/verror-1.10.1.tgz#4bf09eeccf4563b109ed4b3d458380c972b0cdeb",
+        "sha512": "bdeb9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e",
+        "dest-filename": "verror-1.10.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12851,16 +10898,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0",
-        "sha512": "da16a6f173d64ce35a8ce474a2138a3875e49b7fa0681986baddd246ebbbe712ddfd145a63abea821f0d058624efe456deee40b733d0646f05d742c7925d2501",
-        "dest-filename": "vm-browserify-1.1.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec",
-        "sha1": "c066afb582bb1cb4128d60ea92392e94d5e9dbec",
-        "dest-filename": "void-elements-2.0.1.tgz",
+        "url": "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09",
+        "sha1": "614f7fbf8d801f0bb5f0661f5b2f5785750e4f09",
+        "dest-filename": "void-elements-3.1.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12886,23 +10926,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb",
-        "sha1": "2f7f9b8fd10d677262b18a884e28d19618e028fb",
-        "dest-filename": "walker-1.0.7.tgz",
+        "url": "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f",
+        "sha512": "b6cffc13c9796fb918d2f9562dec0e9035cc98f74b7155781a63902f2c6e4acc0826cc1e78566d02c305ee4d4db33cfe4d8050ae56119b33a7af7f7ccb525e99",
+        "dest-filename": "walker-1.0.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz#38500072ee6ece66f3769936950ea1771be1c957",
-        "sha512": "9c215f0483caaf94a1eb5b382cfa72d56b5f8b41c4f22b09dddd986f9fcfa70d8fd81ff779548406329f3747e61c948ad78fb7d4ac0c2a672bcecd863383f45b",
-        "dest-filename": "watchpack-chokidar2-2.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453",
-        "sha512": "f4fdcc5a4e92aca8c7b0690b4f62875dd43ff52364ca825b69bc6728ea097a9b2f263246f2e613477c933f13d0bcd0c8df0e0dcf5c671344cb1cae112157bf31",
-        "dest-filename": "watchpack-1.7.5.tgz",
+        "url": "https://registry.yarnpkg.com/watchpack/-/watchpack-2.3.1.tgz#4200d9447b401156eeca7767ee610f8809bc9d25",
+        "sha512": "c74b7426ec9d228f2a08d72d743ae7d4ecc7fea0f3936fab742382dd8cee999e367e232a990ed3df142eaf291832161f1da3c74e9e19c40c7635f528d4ae9068",
+        "dest-filename": "watchpack-2.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12910,6 +10943,13 @@
         "url": "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df",
         "sha512": "3bce103a7af489cb1b1462d2d0eddb23916cc31cd1afcfe01f05a40e5405b248523ebc905efad33318f118fe3e8966286ae2e806f7c3a64ace6ae67ed226690c",
         "dest-filename": "wbuf-1.7.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad",
+        "sha512": "610f819b1b9381de945d95b7f880867f2a91c875d5943e46b50af9faa8e2356edb17472aaf35f9d341d55cf04ebe05dbe589f30ddfa1d33ab2bfad4a503efe4a",
+        "dest-filename": "webidl-conversions-4.0.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12928,30 +10968,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz#0639372b143262e2b84ab95d3b91a7597061c2c5",
-        "sha512": "7637a573fcc68b3f67663fd4ecf4c18b6562a2b1895c45a8ff796d90f6c3cb1097861117916d1c7bdf5f6a56a89384cf8fe02cc4b897251d0404e6f4ce1f5f29",
-        "dest-filename": "webpack-dev-middleware-3.7.3.tgz",
+        "url": "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz#8fc02dba6e72e1d373eca361623d84610f27be7c",
+        "sha512": "328b89cfead7026f41d4e4ce61a2679faaed0ff95664fcb6b9f4021f704fb3c465a21fc3bba2737b8a7b01e2d81e4562d208899d82da4860c2ed2f8633d6ab86",
+        "dest-filename": "webpack-dev-middleware-5.3.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz#c74028bf5ba8885aaf230e48a20e8936ab8511f0",
-        "sha512": "bb8477991cd991bc5055af8c0568b6b95a41e56e7d1f77a464026c4252944dd97b12571a876121ca04cf2e67855f26d091ff62dbe2f4927ee293d4a75daea285",
-        "dest-filename": "webpack-dev-server-3.11.1.tgz",
+        "url": "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.7.3.tgz#4e995b141ff51fa499906eebc7906f6925d0beaa",
+        "sha512": "9a5c6ad80b08c366a0d35ea78b1933524772384f124f6193cb7e2e292001a757389e18d9bc7f740f965147e50e2d2b06e19dd315a8408bbd9adf2991b5f466f9",
+        "dest-filename": "webpack-dev-server-4.7.3.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/webpack-log/-/webpack-log-2.0.0.tgz#5b7928e0637593f119d32f6227c1e0ac31e1b47f",
-        "sha512": "717f06daf47ff395181b9f45824a0c6a6c075089124a55776c1311b1bc555d5524da3e8d95e08a8d0fd613d79883d598e30db93bdc3cc0a3f8af335916651c52",
-        "dest-filename": "webpack-log-2.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz#19ca69b435b0baec7e29fbe90fb4015de2de4f16",
-        "sha512": "f52e98c8a28a87f3b3fdeaf23354722d50d59b2dcd48f574257311859d7c7c9b2af80c06c54637e17e7854dc24cd8704984903c0dc6e10e6e809911e6c95c101",
-        "dest-filename": "webpack-manifest-plugin-2.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-4.1.1.tgz#10f8dbf4714ff93a215d5a45bcc416d80506f94f",
+        "sha512": "617500c31b5f2882482a4860d3730aba21400fbd8f96ba828b07703b85445dd44ee55d0e44237068ec0065ac0f65a9426e61fd9010e65e735e40ec3e048122a3",
+        "dest-filename": "webpack-manifest-plugin-4.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -12963,9 +10996,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72",
-        "sha512": "e8a2551a50b161d212caeae943420f4e496ff8350bbf4e6bb3686c7885deafa0fb2ab5227110cb15be0850cd52e8b5002b2a4f33f9d28954aebfc8c7bb59b7fd",
-        "dest-filename": "webpack-4.44.2.tgz",
+        "url": "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.1.tgz#570de0af163949fe272233c2cefe1b56f74511fd",
+        "sha512": "cbd108f403b8d898c472b4c914e626572c1565d29551f3af0d43ec25e6b9188af524e106155ab0958d8ad3df1f1682233a40f31e7d808d1bccf1db0166efa008",
+        "dest-filename": "webpack-sources-2.3.1.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde",
+        "sha512": "fc3c8c10eac380b28a206d1f9afb73fb87545ffdc6868cf0826ea23e9f0a461be7f9e41ff7e43b196c5534c937fae08f59f757602e04c4605c9085dd1447c7d7",
+        "dest-filename": "webpack-sources-3.2.3.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/webpack/-/webpack-5.66.0.tgz#789bf36287f407fc92b3e2d6f978ddff1bfc2dbb",
+        "sha512": "34936d193ec82a91b3756ec8c299ffd3d397cfd8a722478843f89b63a07e31d575c7afae45eab3ff9cf52fcf5ecd69e93c35a95c5d136393c260a41d5959fc56",
+        "dest-filename": "webpack-5.66.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -13005,9 +11052,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.5.0.tgz#7752b8464fc0903fec89aa9846fc9efe07351fd3",
-        "sha512": "7f2f91efbc56bf4022a9f2e5e27b86525437ffa6f9b8d7d0e1601b19054c62c8424c208f2bda6c0b59d68775c7bb11950ad95c0c340f416d5cb26988428f9fc2",
-        "dest-filename": "whatwg-url-8.5.0.tgz",
+        "url": "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06",
+        "sha512": "594bbb460d43ae833ba10bc659f3a200adb59fbe0683e4f87a55c441890e86dc8b7968891683862d73ca23ff60cc889ef42b7054b9bcc2dc3a60974acb14a37a",
+        "dest-filename": "whatwg-url-7.1.0.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77",
+        "sha512": "800a23a9bfe6f50f1ae4857de84ddf1c933bd00cc2920b78b97617d8eec49aec8e9cbad5882425b0406617d51022edff69e008a76535eebb5ba5958d9ed42a76",
+        "dest-filename": "whatwg-url-8.7.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -13015,20 +11069,6 @@
         "url": "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6",
         "sha512": "6f065dbf400a2e9a65158d8a6515fa4efcae37ba238ebee5c2483a9a5d2ba08cbd61eb92afb252dfbdaa94d5b5f14418ce060af7388671ead6a993a6127f5536",
         "dest-filename": "which-boxed-primitive-1.0.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f",
-        "sha1": "bba63ca861948994ff307736089e3b96026c2a4f",
-        "dest-filename": "which-module-1.0.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
-        "sha1": "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
-        "dest-filename": "which-module-2.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -13047,6 +11087,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3",
+        "sha512": "78330e45868f359e2c408bae60f0c7750bdfe20c8217dac4115ff23f119fc0f911a1dc048223145174f1fdd7b1f8c7b4c31c79dd2f8d8141da3fbcb73069439a",
+        "dest-filename": "wide-align-1.1.5.tgz",
+        "dest": "flatpak-node/yarn-mirror"
+    },
+    {
+        "type": "file",
         "url": "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca",
         "sha512": "36c9a85da96c5950cc1aea71679474f246bd7e56638e22ef1d501660e2ad88a33cba3b595abf5c45f7da93eb92138f3e39bf0e6da957a70c9e522c830fa40582",
         "dest-filename": "widest-line-3.1.0.tgz",
@@ -13061,149 +11108,121 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-5.1.4.tgz#5ae0bbd455f4e9c319e8d827c055bb86c894fd12",
-        "sha512": "007eb1e6962ae2fc10bdf443587faf7ce78f7cf218434d2708407b749454d5ed27f7ef47311caf23adc5943bed153d80bd7551b17bd4b7b0cd3044e8c892e948",
-        "dest-filename": "workbox-background-sync-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-6.4.2.tgz#bb31b95928d376abcb9bde0de3a0cef9bae46cf7",
+        "sha512": "3fb73cb86e57da4f83308087f7179203d7949423a31c7628078d91abe46d529bb007150e7e5017475cddb0c5a3f352e8a44e208ca5e54f0ec115dd410c01e8ee",
+        "dest-filename": "workbox-background-sync-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-broadcast-update/-/workbox-broadcast-update-5.1.4.tgz#0eeb89170ddca7f6914fa3523fb14462891f2cfc",
-        "sha512": "1d3c935a4a97bc746ea98ef75ebc2f5cfb9dfc537ac7744ece47c53ec463b70fe4199b9990fcdf787e77d6a75419f86dc239ad3bf6735dc584aea57324d75768",
-        "dest-filename": "workbox-broadcast-update-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-broadcast-update/-/workbox-broadcast-update-6.4.2.tgz#5094c4767dfb590532ac03ee07e9e82b2ac206bc",
+        "sha512": "aa7070432134f8f58515cfe7e0849720d138f66e3881b12b789518b7695d187dfe08dacb989d5e80938ec94aaabbd47811bed0ad7726077e029571bb4b7ecb6c",
+        "dest-filename": "workbox-broadcast-update-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-build/-/workbox-build-5.1.4.tgz#23d17ed5c32060c363030c8823b39d0eabf4c8c7",
-        "sha512": "c547199fa49853cbac8ce95f2dbf58dbf7fce86768f9fcb57d7807f2d2478f1829a39dd556ca915f49540f0f3f26ecb33665eea3cbd75f5e295d7da8226f41a3",
-        "dest-filename": "workbox-build-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-build/-/workbox-build-6.4.2.tgz#47f9baa946c3491533cd5ccb1f194a7160e8a6e3",
+        "sha512": "58c7582e10c8b2ecd588e4d70c7fad2751a28e4169e64852628967c51ff5d7399f84d0edba8ee3a1fef6c4f185cbe291a6ccfab6e837f51862bc28fbeeaa8ed3",
+        "dest-filename": "workbox-build-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-5.1.4.tgz#9ff26e1366214bdd05cf5a43da9305b274078a54",
-        "sha512": "d1b7ef319b3439fd52e5c76cc1f40ad015edeae954e64543e25c1eaf609e23ed377331e9ad747757863c94f4e8a1a9a7ede1cff08cb08b9423c80323c34a9ab8",
-        "dest-filename": "workbox-cacheable-response-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-6.4.2.tgz#ebcabb3667019da232e986a9927af97871e37ccb",
+        "sha512": "f451355bf70a7df935009cc89b180437471e5a9cb3d6da8d8d956d037fcb02f60bdc00b949b22485ced908ef365a63bd2234dfbbc56eb765ff0bb56231217b4c",
+        "dest-filename": "workbox-cacheable-response-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-core/-/workbox-core-5.1.4.tgz#8bbfb2362ecdff30e25d123c82c79ac65d9264f4",
-        "sha512": "fb889141a9ffd43f08f359d1d8be6f71b69a16c9190b608bd7b4cb6ef595cd0e2a885ff2b4e185e97795e78a55c40bca52d90b00d864f13c8850cb62330da80e",
-        "dest-filename": "workbox-core-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-core/-/workbox-core-6.4.2.tgz#f99fd36a211cc01dce90aa7d5f2c255e8fe9d6bc",
+        "sha512": "d54e9c74460f71a8d15e26e84a5a49c7a53b4ef84829bc5145eadf7a9009bb686788ac09dc31c82e3a54ff3c77cafcd204259c3490e815a95fed581dedecbfaf",
+        "dest-filename": "workbox-core-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-5.1.4.tgz#92b5df461e8126114943a3b15c55e4ecb920b163",
-        "sha512": "a033bfe620bae61d84abb8dcb40bfce7c5b6f827915b97b48d904c3515e9ce9d193efb93e866e55221e702c0b95b994036cd504bd6ad54e9b889fac189863b01",
-        "dest-filename": "workbox-expiration-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-6.4.2.tgz#61613459fd6ddd1362730767618d444c6b9c9139",
+        "sha512": "d216e9063d2d0e75be0d93949b066a9ed07ff31ad73a03b7e22eecd344a2fd594526fbe944a83595e5dd1c753cca4a1205debe17628370c3f7b30a028b982e2f",
+        "dest-filename": "workbox-expiration-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-5.1.4.tgz#b3376806b1ac7d7df8418304d379707195fa8517",
-        "sha512": "d081612a8115aeb787a4a81c3a875d57ea086955c114a5d4cc954123e9dbd1bc6673062e64c76d7814e9f0010325a70436d73dc5b474c1af510c29d8b020cb8c",
-        "dest-filename": "workbox-google-analytics-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-6.4.2.tgz#eea7d511b3078665a726dc2ee9f11c6b7a897530",
+        "sha512": "bbe831b378d7a2f3dbd68ba5e024c139bf93f5f4b5a191be644e80cd2ee5e34be7c9f255efd0da2c1be5a4465f5c6bf70a331d575b13fe5b5d3ab2b3a3b1dc1b",
+        "dest-filename": "workbox-google-analytics-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-5.1.4.tgz#30d1b720d26a05efc5fa11503e5cc1ed5a78902a",
-        "sha512": "59fd37a2cbcad304df9407ca5db6bffd09960b9048688640454d3724884010edb0481d810d139623c43fce689a9dfe7891d57b7b578b68811986d8782b83327d",
-        "dest-filename": "workbox-navigation-preload-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-6.4.2.tgz#35cd4ba416a530796af135410ca07db5bee11668",
+        "sha512": "be2c9e8e50ad94ab1b242047c214816d6739eccc0f5ef52b73c3fb77ef3b0310463d4f89b96913ea7bc100d815805cfa154842bd10bc698b7e07585e968d7aea",
+        "dest-filename": "workbox-navigation-preload-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-5.1.4.tgz#874f7ebdd750dd3e04249efae9a1b3f48285fe6b",
-        "sha512": "802205ac15e65502c5c2f033b862c29a45181958416fb0f593f20bee950950ee7169c8cb70551a2e79eca157a90460222b0df81d4d72fd8baabd32a29bda8064",
-        "dest-filename": "workbox-precaching-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-6.4.2.tgz#8d87c05d54f32ac140f549faebf3b4d42d63621e",
+        "sha512": "099eaec0537fdb06f89e81d59402cbed4a8f15b2df7b3ffd4b6180cc601bd1293cefaba5f6e91128f249ea0b6cc5f1361d24f0ab0bb23556bac56c9ec89d5748",
+        "dest-filename": "workbox-precaching-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-5.1.4.tgz#7066a12c121df65bf76fdf2b0868016aa2bab859",
-        "sha512": "d474ae8cb8e04dea311eb311da6b835b674a771a8218c73529b7b219c9a3659022cc94c5c2eec258b0e62efe8ed5c79662b85fb8b1493beba660c75d9365cc87",
-        "dest-filename": "workbox-range-requests-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-6.4.2.tgz#050f0dfbb61cd1231e609ed91298b6c2442ae41b",
+        "sha512": "4a8c05df3ebd86bdcfa3fc3bfb16ab59fcf1257ff7168d2e486ef6660e20e455969c7a6adb33ef81b59eac16486bcd73a49554758a4c6b76a4249b2ff8b68ed5",
+        "dest-filename": "workbox-range-requests-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-5.1.4.tgz#3e8cd86bd3b6573488d1a2ce7385e547b547e970",
-        "sha512": "f258e49d17ea135bc442d9ccb737e4b0bf945cef36da32651d3211efe06d26ec50d7bf963d97ec1eabe4d729d1fefd041e2938c76fbcdba1e4c29821e062830b",
-        "dest-filename": "workbox-routing-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-recipes/-/workbox-recipes-6.4.2.tgz#68de41fa3a77b444b0f93c9c01a76ba1d41fd2bf",
+        "sha512": "fe85719591690231556d8fb73e81845def2acafb66a8cad375685b39f6f0a24345b5467f242b5a9c32a0c03bfdc7701e6ea180a0946f40d4abbb41789c6fa058",
+        "dest-filename": "workbox-recipes-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-5.1.4.tgz#96b1418ccdfde5354612914964074d466c52d08c",
-        "sha512": "5554b9ecba5a2537635b746066f3f05f436584d9ac711ece43d6cff8dff7e1c60c0f35cbc80ea4a967df3fa40a5d291c6b5385a3fbfabfb856ef3aeb82ea3a10",
-        "dest-filename": "workbox-strategies-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-6.4.2.tgz#65b1c61e8ca79bb9152f93263c26b1f248d09dcc",
+        "sha512": "d2cb3f9fd3c07078d3cb801dee5da9baea1de16b6c9d162ef41ae61dcbba0e4e0f816789a35b795671ae7cfc4db5cbb23c643739d9cc7659a1309e7bb12aeb4b",
+        "dest-filename": "workbox-routing-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-5.1.4.tgz#05754e5e3667bdc078df2c9315b3f41210d8cac0",
-        "sha512": "c54f32b85d6123f5dc56125401f6d02dad60b9052174b30f40991d4f4927e873f90b088f3868979d216af34ac01b86f590950285040818faeae37f45414355af",
-        "dest-filename": "workbox-streams-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-6.4.2.tgz#50c02bf2d116918e1a8052df5f2c1e4103c62d5d",
+        "sha512": "61787d13d7591843b51223c2de33ded826f3b4ee564fc46e8fcc22619339e97a84269e589464eda918e0855f89a2f58eaa459d47e6a6269577d4a3d6414be7d5",
+        "dest-filename": "workbox-strategies-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-5.1.4.tgz#2bb34c9f7381f90d84cef644816d45150011d3db",
-        "sha512": "f712a72b0f79697c1235cf2493c8248b81d4d20d16e8a5eefb192cef016e0bb874b1e99b1674eb2ad724a99c5b4a8778d530da1a1fa05940392115eb2f410244",
-        "dest-filename": "workbox-sw-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-6.4.2.tgz#3bc615cccebfd62dedf28315afb7d9ee177912a5",
+        "sha512": "44e1069591c65448296b96ce65e7e224456c8b93ec163246f5777ec270db029b023bdc6af6b605a2917e211abdb428726338419f2936849c5b4155a9873deca2",
+        "dest-filename": "workbox-streams-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-webpack-plugin/-/workbox-webpack-plugin-5.1.4.tgz#7bfe8c16e40fe9ed8937080ac7ae9c8bde01e79c",
-        "sha512": "3d969f1781e9ba066776a2128b7ad9e192b80380f13bcac0aadd85c11a6d82c0f1ecd17c4d528ff3afe1b87aae52c46330642596c35d9f814d97c083fd4bca99",
-        "dest-filename": "workbox-webpack-plugin-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-6.4.2.tgz#9a6db5f74580915dc2f0dbd47d2ffe057c94a795",
+        "sha512": "036a9dbbd4cb92d7c8339344ffcfb26307d6bbe2600da0a46e8e6292b932d9ceebf6fd97e83709fb348ba613471cbc0cff47959395d57f5982e471a162932186",
+        "dest-filename": "workbox-sw-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/workbox-window/-/workbox-window-5.1.4.tgz#2740f7dea7f93b99326179a62f1cc0ca2c93c863",
-        "sha512": "bd742d81378c094abfe2905631f417f047bb376c150b843b5d816a2e77db5c9da1a9ec3f714d6e3130f62aa184804a44e3fdf496ec48c6013e2e421af2094163",
-        "dest-filename": "workbox-window-5.1.4.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-webpack-plugin/-/workbox-webpack-plugin-6.4.2.tgz#aad9f11b028786d5b781420e68f4e8f570ea9936",
+        "sha512": "0a213033a91a251931d5c3f9c4792c9f5dda6d3cd4a8c1e230c969e4487fbf8c1171e7600d3cafe94a3cf8783d32ead16c70e8b0ee6cb9a3f217dbb056be3f09",
+        "dest-filename": "workbox-webpack-plugin-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8",
-        "sha512": "aefc3741365cf25031c95aea7121959b9c8ffc827651c07753482b684dcb085a19d189f6c78128552a8929d07f4f933e14b7113e3cf84c369c45fdce09f354cf",
-        "dest-filename": "worker-farm-1.7.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/worker-rpc/-/worker-rpc-0.1.1.tgz#cb565bd6d7071a8f16660686051e969ad32f54d5",
-        "sha512": "3f55a332b501dea809348f637e6a59fe1b660448c587fffa97fe72f120fd860d447f9cd34d55684634eb4c4ccfacd050be684cc64a13b23397375d06594eda0a",
-        "dest-filename": "worker-rpc-0.1.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85",
-        "sha1": "d8fc3d284dd05794fe84973caecdd1cf824fdd85",
-        "dest-filename": "wrap-ansi-2.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09",
-        "sha512": "402d7f88dff6fd13d52798d82bc046b6d8f9cfcdcb9922a6bdbbeb5cf3422d94846f7d8a2950c90e5fcc3add8dd35a94d87fc593311af4f2ada3506a0e3b5ded",
-        "dest-filename": "wrap-ansi-5.1.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53",
-        "sha512": "afa94f7011b1657948732984bbb227c43321756d0a0f1a4b82814b720b9ab3109a27f48e219c0835ab4af4a63fb5ff99ae5cb038a5345038f70135d405fc495c",
-        "dest-filename": "wrap-ansi-6.2.0.tgz",
+        "url": "https://registry.yarnpkg.com/workbox-window/-/workbox-window-6.4.2.tgz#5319a3e343fa1e4bd15a1f53a07b58999d064c8a",
+        "sha512": "295c912a6ac983b881faeca6fc1fc29c4504146f42be74d4d41ab9c695c76ed803f65f928437a44a5d70629ab0fced097de79054e15bf0288d7ef9f05b0aa759",
+        "dest-filename": "workbox-window-6.4.2.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -13229,16 +11248,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e",
-        "sha512": "ce6865b68491f2ed5c9c3b03e374d7e7d9b3a0c66c2caa94c1ec9804022f4e7811dec85cd16e9a399ca5666abfee1ab25713dd8bee547764089db960c84ef67f",
-        "dest-filename": "ws-6.2.2.tgz",
+        "url": "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b",
+        "sha512": "e862e00aaa36732d80dab8c2345971412e999631bf72865f65772595d23c141ff51b7082237e9977cc72d87ac55400a2f2d7e4e57ae02d0124f8fd139f3f5470",
+        "dest-filename": "ws-7.5.6.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59",
-        "sha512": "426f24f288cd408331ed2f99a7cbbfb873b1ed06b3bf762fe2aebc32259658e2618b01b95b7c7b8aa991b49a3cc71adc899518e2f4715132422ae467176f1967",
-        "dest-filename": "ws-7.4.4.tgz",
+        "url": "https://registry.yarnpkg.com/ws/-/ws-8.4.1.tgz#ce1a17e553d2b794e017fa94887808db5c67f614",
+        "sha512": "e9ea90e32376cb6c6ff1bf8181b914ccf3f27e8fcf0e5dd53966f4e991348c8158c2e1ccb0c40de85ee8f38cb125809b95f091031ce9539f567b846be30d0bbb",
+        "dest-filename": "ws-8.4.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -13285,13 +11304,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e",
-        "sha512": "1686a3e455d5ce09fbc45cec29e34875ef60e9a141c533e2dfb8b0b27a3c42f0299ad83b298aebf8e3f244770917b76e7766b99c64415cade7d1d2fad867fb3c",
-        "dest-filename": "xmldom-0.5.0.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
         "url": "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54",
         "sha512": "2ca614d620172575200179fd5118e2bbe3168725171ecbdfa7b99cb989bd75250a2b4fc28edad4c050310fcdbf98259bb4bb068c521a774c08b28778ceb4c011",
         "dest-filename": "xtend-4.0.2.tgz",
@@ -13299,23 +11311,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696",
-        "sha512": "b866475e41e7845d1779e00f82729f3efd5b80a018c95be634bd7194ab0f6193da207c46b62da11eabce090bfbd5732c2f1bb54237ab824aa88149e6b390f761",
-        "dest-filename": "y18n-3.2.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4",
-        "sha512": "c0d732e0dbe33182fc82881659800eed915615f1dc6dd6c4e7bb593bc7b871ba63f2d7d4730af0a9297769df07c6961609d5dc25409e28a652eb602fd5a7dfc1",
-        "dest-filename": "y18n-4.0.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18",
-        "sha512": "86c454af8145aef861447d76c0e75fb37f06cbb936145cc1f6a80df6fdda2f2911ab475171d729cf90bd171752d8dba13ab23feb6f1bfca493277af01f2b184a",
-        "dest-filename": "y18n-5.0.5.tgz",
+        "url": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+        "sha512": "d297c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+        "dest-filename": "y18n-5.0.8.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -13323,13 +11321,6 @@
         "url": "https://registry.yarnpkg.com/yaku/-/yaku-0.16.7.tgz#1d195c78aa9b5bf8479c895b9504fd4f0847984e",
         "sha1": "1d195c78aa9b5bf8479c895b9504fd4f0847984e",
         "dest-filename": "yaku-0.16.7.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd",
-        "sha512": "6b850641a58f1f9f663975189c01b67b09dc412e22e05e374efdc9a0033eb365430264bd36c2bc1a90cc2eb0873e4b054fb8772ba4cea14367da96fb4685f1e2",
-        "dest-filename": "yallist-3.1.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -13348,44 +11339,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38",
-        "sha512": "de56ec3517ff8fe03842e4997c3440ec74527d6af33b4623a9325de648c0ab7ed97a9d421206989ab1fd4371b03e207d707c9dd58d54c208068491a8c62a5bce",
-        "dest-filename": "yargs-parser-13.1.2.tgz",
+        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee",
+        "sha512": "cb5d67184953215f824f766ff6ded52a5f90de14d0a13f5ad50cdece1865e91a76d6027f2154d6ed9df2f4459786e5010b64a19dff835f46a7b5e72903048ff3",
+        "dest-filename": "yargs-parser-20.2.9.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0",
-        "sha512": "a39d23d09793a32ff82ba39971a4265ba9725d72a1abb72c4445dc0f0936a2614f244c1434e56d24abe60ebf442357c025953265c445ee4c460569915ee76b09",
-        "dest-filename": "yargs-parser-18.1.3.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a",
-        "sha512": "162364bdb787cc1fecc8e8c85311430a78527f300bf11e6fb38d0c80b141a2b5c008238011a5aed20459975e2f1bc311f403892196e692386eb2a0586771d31f",
-        "dest-filename": "yargs-parser-20.2.7.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c",
-        "sha1": "29cceac0dc4f03c6c87b4a9f217dd18c9f74871c",
-        "dest-filename": "yargs-parser-4.2.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd",
-        "sha512": "017dd9c3988faee37989eeb119120382a913f9986746564c2cc1c0b3cb60ee746bbb2d8d6fe8b9a3d6f082102882d334f2ad5da6bd8b5684bc2924cc62959753",
-        "dest-filename": "yargs-13.3.2.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8",
-        "sha512": "69e3dbc4399c616fbe3daa81b09f8761417009dbf82d5bdd9e1072efc139ecf228afcfce56f84cac00c51440e1f031c3151bff3bd8b794f86c10d8ceed05f4f8",
-        "dest-filename": "yargs-15.4.1.tgz",
+        "url": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55",
+        "sha512": "cfd900a5850e0b0a1e67bf2b7d161859d894fe234bea6c3062592465f268c8c475c69b3e344057e57ed7991a719191e15c9ebe132d342302b1041496f45223c8",
+        "dest-filename": "yargs-parser-21.0.0.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {
@@ -13397,16 +11360,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea",
-        "sha512": "5df47c76eeae6b82bab8b1a6e52e9f03e1482689bf31d25c14d558f2078b969daff0661b3970f8101d6d3cd66c467e2f0732863206f90d164c796b8573618ef1",
-        "dest-filename": "yargs-17.2.1.tgz",
-        "dest": "flatpak-node/yarn-mirror"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208",
-        "sha1": "782ec21ef403345f830a808ca3d513af56065208",
-        "dest-filename": "yargs-6.6.0.tgz",
+        "url": "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9",
+        "sha512": "59400d41e5608cb6cdb04986936d1ffa794780eab3445a6219655a06b60660818034822ede55a3a328b47cd94598992f7e1099e815c835eeff5b63b66d5e2268",
+        "dest-filename": "yargs-17.3.1.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {

--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -100,8 +100,8 @@ modules:
         dest: flatpak-node/electron-cache
 
       - type: archive
-        url: https://github.com/mifi/lossless-cut/archive/v3.40.0.tar.gz
-        sha256: c6f47d9a19b4537256abfb87abeca908217d52bda4bf3975abed3abe82cc83ce
+        url: https://github.com/mifi/lossless-cut/archive/v3.42.0.tar.gz
+        sha256: 8417756f1aef12f32aaf16854a0fe0c6b371ebf8cf52e7a0dc7d2cdc9173e110
 
       - type: script
         dest-filename: run.sh

--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -1,6 +1,6 @@
 app-id: no.mifi.losslesscut
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node14

--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -107,7 +107,7 @@ modules:
 
       - type: archive
         url: https://github.com/mifi/lossless-cut/archive/v3.42.0.tar.gz
-        sha256: 8417756f1aef12f32aaf16854a0fe0c6b371ebf8cf52e7a0dc7d2cdc9173e110
+        sha256: c141cb0ead6da7ba819e34dbad1aec430066278f5f711a75afc67a3640671d52
 
       - type: script
         dest-filename: run.sh

--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -57,6 +57,12 @@ modules:
             - type: archive
               url: https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
               sha256: 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f
+        - name: libvips
+          sources:
+            - type: archive
+              url: https://github.com/libvips/libvips/releases/download/v8.12.1/vips-8.12.1.tar.gz
+              sha256: 474d8439244cd26c504812fd623259f806c32553b38d2a54798c9766135f5a5c
+ 
           
     build-commands:
       - node --version


### PR DESCRIPTION
phantomjs breaks somehow :-|

```
error /run/build/lossless-cut/node_modules/phantomjs-prebuilt: Command failed.
Exit code: 1
Command: node install.js
Arguments: 
Directory: /run/build/lossless-cut/node_modules/phantomjs-prebuilt
Output:
Considering PhantomJS found at /app/bin/phantomjs
Found PhantomJS at /app/bin/phantomjs ...verifying
Error verifying phantomjs, continuing Error: Command failed: /app/bin/phantomjs --version
Auto configuration failed
140658533816128:error:260B6091:engine routines:DYNAMIC_LOAD:version incompatibility:eng_dyn.c:487:
140658533816128:error:260BC066:engine routines:INT_ENGINE_CONFIGURE:engine configuration error:eng_cnf.c:204:section=pkcs11_section, name=dynamic_path, value=/usr/lib/x86_64-linux-gnu/engines-1.1/libpkcs11.so
140658533816128:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=engines, value=engine_section, retcode=-1      
    at ChildProcess.exithandler (child_process.js:383:12)
    at ChildProcess.emit (events.js:400:28)
    at maybeClose (internal/child_process.js:1058:16)
    at Socket.<anonymous> (internal/child_process.js:443:11)
    at Socket.emit (events.js:400:28)
    at Pipe.<anonymous> (net.js:686:12) {
  killed: false,
  code: 1,
  signal: null,
  cmd: '/app/bin/phantomjs --version'
}
Downloading https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
Saving to /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
Receiving...
Error making request.
Error: getaddrinfo EAI_AGAIN github.com
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:71:26)
```

looks like it doesn't like libpkcs11.so.