### PR TITLE
manifest: remove phantomjs because it's not needed anymore

### DIFF
--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -47,16 +47,6 @@ modules:
 
     modules:
         - ffmpeg.yaml
-        - name: phantomjs
-          buildsystem: "simple"
-          build-commands: 
-            - mv bin/phantomjs /app/bin/
-          cleanup:
-            - '*' # I don't know.. do we need it for running the app?
-          sources:
-            - type: archive
-              url: https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
-              sha256: 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f
         - name: libvips
           sources:
             - type: archive


### PR DESCRIPTION
It got removed https://github.com/mifi/lossless-cut/commit/189056dfcdec360c9882e4fad8919b3d5c34a404