### PR TITLE
manifest: Make test-command a string rather than a list

### DIFF
--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -84,8 +84,7 @@ modules:
 
     test-commands:
       # This is what the app would call. Let's try it ourselves to see whether we're good.
-      - /app/lossless-cut/resources/ffmpeg '-hide_banner' '-f' 'lavfi' '-i' 'nullsrc=s=256x256:d=1'
-        '-f' 'null' '-'
+      - "/app/lossless-cut/resources/ffmpeg '-hide_banner' '-f' 'lavfi' '-i' 'nullsrc=s=256x256:d=1' '-f' 'null' '-'"
 
     sources:
       # The chromedriver package tries to download a bunch of files


### PR DESCRIPTION
The bot complains:

{
    "errors": [
        "jsonschema-validation-error"
    ],
    "warnings": [
        "module-lossless-cut-source-sha1-deprecated",
        "flathub-json-redundant-only-arches",
        "toplevel-command-is-path"
    ],
    "jsonschema": [
        "[\"/app/lossless-cut/resources/ffmpeg '-hide_banner' '-f' 'lavfi' '-i' 'nullsrc=s=256x256:d=1' '-f' 'null' '-'\"] is not of type 'string'"
    ]
}

I hope this fixes it.