### PR TITLE
libvips: use tar.xz rather than tar.gz since the latter doesn't exist

### DIFF
--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -57,7 +57,7 @@ modules:
               type: json
               url: https://api.github.com/repos/libvips/libvips/releases/latest
               version-query: .tag_name | sub("^v"; "")
-              url-query: .assets[] | select(.name=="vips-" + $version + ".tar.gz")
+              url-query: .assets[] | select(.name=="vips-" + $version + ".tar.xz")
                 | .browser_download_url
     build-commands:
       - node --version


### PR DESCRIPTION
There are no tar.gzs any more, it seems. And that makes the flathub CI fail.