### PR TITLE
Fix losslesscut flathub builds by providing the appropriate metadata

### DIFF
--- a/ffmpeg.yaml
+++ b/ffmpeg.yaml
@@ -48,8 +48,8 @@ config-opts:
 
 sources:
   - type: archive
-    url: https://ffmpeg.org/releases/ffmpeg-6.1.1.tar.xz
-    sha256: 8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968
+    url: https://ffmpeg.org/releases/ffmpeg-7.0.2.tar.xz
+    sha256: 8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389
     x-checker-data:
       type: anitya
       project-id: 5405

--- a/no.mifi.losslesscut.metainfo.xml
+++ b/no.mifi.losslesscut.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>no.mifi.losslesscut</id>
+  
+  <name>LosslessCut</name>
+  <summary> The swiss army knife of lossless video/audio editing </summary>
+  
+  <metadata_license>MIT</metadata_license>
+  <project_license>GPL-2.0-only</project_license>
+  
+  <description>
+    <p>
+      LosslessCut aims to be the ultimate cross platform FFmpeg GUI for extremely fast and lossless operations on video, audio, subtitle and other related media files. The main feature is lossless trimming and cutting of video and audio files, which is great for saving space by rough-cutting your large video files taken from a video camera, GoPro, drone, etc. It lets you quickly extract the good parts from your videos and discard many gigabytes of data without doing a slow re-encode and thereby losing quality. Or you can add a music or subtitle track to your video without needing to encode. Everything is extremely fast because it does an almost direct data copy, fueled by the awesome FFmpeg which does all the grunt work.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">no.mifi.losslesscut.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://static.mifi.no/losslesscut/main_screenshot3.jpg</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -34,8 +34,8 @@ modules:
         buildsystem: meson
         sources:
           - type: archive
-            url: https://github.com/libvips/libvips/releases/download/v8.15.1/vips-8.15.1.tar.xz
-            sha256: 06811f5aed3e7bc03e63d05537ff4b501de5283108c8ee79396c60601a00830c
+            url: https://github.com/libvips/libvips/releases/download/v8.15.3/vips-8.15.3.tar.xz
+            sha256: 3e27d9f536eafad64013958fe9e8a1964c90b564c731d49db7c1a1c11b1052a0
             x-checker-data:
               type: json
               url: https://api.github.com/repos/libvips/libvips/releases/latest

--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -64,6 +64,7 @@ modules:
       - desktop-file-edit --set-key Exec --set-value /app/bin/run.sh  no.mifi.losslesscut.desktop
       - install -Dm 0644 no.mifi.losslesscut.desktop  /app/share/applications/no.mifi.losslesscut.desktop
       - install -Dm 0644 no.mifi.losslesscut.appdata.xml  /app/share/metainfo/no.mifi.losslesscut.appdata.xml
+      - install -Dm 0644 no.mifi.losslesscut.metainfo.xml /app/share/metainfo/no.mifi.losslesscut.metainfo.xml
       - install -Dm 0644 src/icon.svg /app/share/icons/hicolor/scalable/apps/no.mifi.losslesscut.svg
 
     test-commands:


### PR DESCRIPTION
Used [this](https://www.freedesktop.org/software/appstream/metainfocreator/#/guiapp) official generator tool and metadata i could find publicly in the losslesscut repo to fix the issue presented in #59 

This PR is based on the latest updated bot PR in #65.

it also effectively closes #58 #59 #60 #63 #64 and #65

When generating the file, I also selected the option to generate meson scripts to help maintain this file. However since im unfamiliar with how flatpaks work, ill include them here for someone more knowledgeable to tell me whether i should add them:

### Script 1: Meson Validation Testcase

From the tool: "Adjust the data location in metainfo_file and add this snippet to your Meson build definition in order to validate the MetaInfo file as part of the project's tests.:
```
# Validate MetaInfo file
metainfo_file = '/path/to/no.mifi.losslesscut.metainfo.xml'
ascli_exe = find_program('appstreamcli', required: false)
if ascli_exe.found()
  test('validate metainfo file',
        ascli_exe,
        args: ['validate',
               '--no-net',
               '--pedantic',
               metainfo_file]
  )
endif
```
### Script 2: MetaInfo Localization

From the tool: "AppStream MetaInfo files are recognized by xgettext, so you just need to add no.mifi.losslesscut to your POTFILES.in to generate templates for all translatable elements in the file. When building the software, you can then instruct your build system to merge in the translations into the new file before installing the translated file as /usr/share/metainfo/no.mifi.losslesscut.metainfo.xml.
Meson Snippet

This code fragment for the Meson build system can be used to perform the merge-and-install step, when templates were already generated in a previous step."

```
# Localize a MetaInfo file and install it
i18n = import('i18n')

# NOTE: Remember to add the XML file to POTFILES.in!
metainfo_file = '/path/to/no.mifi.losslesscut.metainfo.xml'
i18n.merge_file(
    input:  metainfo_file,
    output: 'no.mifi.losslesscut.metainfo.xml',
    type: 'xml',
    po_dir: join_paths (meson.source_root(), 'po'),
    install: true,
    install_dir: join_paths (get_option ('datadir'), 'metainfo')
)
```