### PR TITLE
bump runtime to 23.08

### DIFF
--- a/no.mifi.losslesscut.yaml
+++ b/no.mifi.losslesscut.yaml
@@ -1,6 +1,6 @@
 app-id: no.mifi.losslesscut
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node18


### PR DESCRIPTION
22.08 is EOL
it doesn't build for 24.08 because node18 is only available up to 23.08



